### PR TITLE
Add multi pcsp generator

### DIFF
--- a/Generate_PCSP.py
+++ b/Generate_PCSP.py
@@ -5,14 +5,19 @@ from tqdm import tqdm as tqdm
 import warnings
 warnings.simplefilter("ignore")
 
+data = read_data_from_csv()
 
 # generate pcsp file
-def generate_pcsp(params, date, ply1_name, ply2_name, hand1, hand2):
+def generate_pcsp(date, ply1_name, ply2_name, ply1_hand, ply2_hand, pcsp_filename):
+    params = get_params(
+        data, date, ply1_name, ply2_name, ply1_hand, ply2_hand
+    )
     VAR = 'var.txt'
-    HAND = '%s_%s.txt' % (hand1, hand2)
-    file_name = '%s_%s_' % (hand1, hand2)
-    file_name += '%s_%s_%s.pcsp' % (date, ply1_name.replace(' ',
-                                    '-'), ply2_name.replace(' ', '-'))
+    HAND = '%s_%s.txt' % (ply1_hand, ply2_hand)
+    # Keeping it here in case its needed
+    # file_name = '%s_%s_' % (hand1, hand2)
+    # file_name += '%s_%s_%s.pcsp' % (date, ply1_name.replace(' ',
+    #                                '-'), ply2_name.replace(' ', '-'))
     # write to file
     lines = []
     with open(VAR) as f:
@@ -23,15 +28,12 @@ def generate_pcsp(params, date, ply1_name, ply2_name, hand1, hand2):
     with open(HAND) as f:
         lines_3 = f.readlines()
     lines = lines_1 + lines_2 + lines_3
-    with open(file_name, 'w') as f:
+    with open(pcsp_filename, 'w') as f:
         for line in lines:
             f.write(line)
 
 
-date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender = get_args()
-data = read_data_from_csv()
-params = get_params(
-    data, date, ply1_name, ply2_name, ply1_hand, ply2_hand
-)
+# date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender, pcsp_filename = get_args()
 
-generate_pcsp(params, date, ply1_name, ply2_name, ply1_hand, ply2_hand)
+
+# generate_pcsp(date, ply1_name, ply2_name, ply1_hand, ply2_hand, pcsp_filename)

--- a/MDP_pred.csv
+++ b/MDP_pred.csv
@@ -1,580 +1,580 @@
 date,P1Name,P2Name,P1WinProb,P2WinProb,P1Hand,P2Hand
-2018-01-06,Nick Kyrgios,Grigor Dimitrov,0.6473,0.3527,LH,RH
+2018-01-06,Nick Kyrgios,Grigor Dimitrov,0.6473,0.3527,RH,RH
 2018-01-02,Borna Coric,Pablo Carreno Busta,0.5472,0.4528,RH,RH
-2018-01-06,Gael Monfils,Andrey Rublev,0.5587,0.4412,RH,LH
-2018-01-09,Robin Haase,Casper Ruud,0.5998,0.4002,LH,LH
-2018-01-10,Karen Khachanov,Pablo Cuevas,0.3717,0.6283,LH,RH
+2018-01-06,Gael Monfils,Andrey Rublev,0.5587,0.4412,RH,RH
+2018-01-09,Robin Haase,Casper Ruud,0.5998,0.4002,RH,RH
+2018-01-10,Karen Khachanov,Pablo Cuevas,0.3717,0.6283,RH,RH
 2018-01-12,Juan Martin Del Potro,David Ferrer,0.691,0.309,RH,RH
-2018-01-13,Roberto Bautista Agut,Juan Martin Del Potro,0.4231,0.577,RH,LH
-2018-01-15,Damir Dzumhur,Paolo Lorenzi,0.582,0.418,LH,LH
-2018-01-17,Pablo Carreno Busta,Gilles Simon,0.4495,0.5505,LH,RH
+2018-01-13,Roberto Bautista Agut,Juan Martin Del Potro,0.4231,0.577,RH,RH
+2018-01-15,Damir Dzumhur,Paolo Lorenzi,0.582,0.418,RH,RH
+2018-01-17,Pablo Carreno Busta,Gilles Simon,0.4495,0.5505,RH,RH
 2018-01-19,Grigor Dimitrov,Andrey Rublev,0.5196,0.4803,RH,RH
-2018-01-20,Tomas Berdych,Juan Martin Del Potro,0.4304,0.5696,RH,LH
-2018-01-21,Marin Cilic,Pablo Carreno Busta,0.6217,0.3783,LH,LH
-2018-01-21,Grigor Dimitrov,Nick Kyrgios,0.363,0.6369,LH,RH
+2018-01-20,Tomas Berdych,Juan Martin Del Potro,0.4304,0.5696,RH,RH
+2018-01-21,Marin Cilic,Pablo Carreno Busta,0.6217,0.3783,RH,RH
+2018-01-21,Grigor Dimitrov,Nick Kyrgios,0.363,0.6369,RH,RH
 2018-01-22,Tomas Berdych,Fabio Fognini,0.6863,0.3137,RH,RH
-2018-01-22,Hyeon Chung,Novak Djokovic,0.4047,0.5953,RH,LH
-2018-01-23,Kyle Edmund,Grigor Dimitrov,0.5879,0.4121,LH,LH
-2018-01-24,Roger Federer,Tomas Berdych,0.6765,0.3235,LH,RH
+2018-01-22,Hyeon Chung,Novak Djokovic,0.4047,0.5953,RH,RH
+2018-01-23,Kyle Edmund,Grigor Dimitrov,0.5879,0.4121,RH,RH
+2018-01-24,Roger Federer,Tomas Berdych,0.6765,0.3235,RH,RH
 2018-01-26,Roger Federer,Hyeon Chung,0.7659,0.2342,RH,RH
-2018-02-07,David Goffin,Gilles Simon,0.6005,0.3995,RH,LH
-2018-02-09,Jo Wilfried Tsonga,Andrey Rublev,0.5757,0.4243,LH,LH
-2018-02-10,Richard Gasquet,David Goffin,0.4567,0.5433,LH,RH
+2018-02-07,David Goffin,Gilles Simon,0.6005,0.3995,RH,RH
+2018-02-09,Jo Wilfried Tsonga,Andrey Rublev,0.5757,0.4243,RH,RH
+2018-02-10,Richard Gasquet,David Goffin,0.4567,0.5433,RH,RH
 2018-02-10,Lucas Pouille,Jo Wilfried Tsonga,0.4541,0.5459,RH,RH
-2018-02-15,Roger Federer,Philipp Kohlschreiber,0.6558,0.3442,RH,LH
-2018-02-16,Grigor Dimitrov,Andrey Rublev,0.5065,0.4935,LH,LH
-2018-02-17,Grigor Dimitrov,David Goffin,0.4757,0.5243,LH,RH
+2018-02-15,Roger Federer,Philipp Kohlschreiber,0.6558,0.3442,RH,RH
+2018-02-16,Grigor Dimitrov,Andrey Rublev,0.5065,0.4935,RH,RH
+2018-02-17,Grigor Dimitrov,David Goffin,0.4757,0.5243,RH,RH
 2018-02-23,Tomas Berdych,Damir Dzumhur,0.6027,0.3973,RH,RH
-2018-02-23,Lucas Pouille,Filip Krajinovic,0.5421,0.4579,RH,LH
-2018-02-22,Aljaz Bedene,Pablo Carreno Busta,0.5449,0.4551,LH,LH
-2018-02-27,Ryan Harrison,John Isner,0.4485,0.5515,LH,RH
+2018-02-23,Lucas Pouille,Filip Krajinovic,0.5421,0.4579,RH,RH
+2018-02-22,Aljaz Bedene,Pablo Carreno Busta,0.5449,0.4551,RH,RH
+2018-02-27,Ryan Harrison,John Isner,0.4485,0.5515,RH,RH
 2018-02-28,Ryan Harrison,Diego Schwartzman,0.7974,0.2026,RH,RH
-2018-03-01,Juan Martin Del Potro,David Ferrer,0.7606,0.2394,RH,LH
-2018-03-02,Juan Martin Del Potro,Dominic Thiem,0.6331,0.3669,LH,LH
-2018-03-04,Juan Martin Del Potro,Kevin Anderson,0.5293,0.4707,LH,RH
+2018-03-01,Juan Martin Del Potro,David Ferrer,0.7606,0.2394,RH,RH
+2018-03-02,Juan Martin Del Potro,Dominic Thiem,0.6331,0.3669,RH,RH
+2018-03-04,Juan Martin Del Potro,Kevin Anderson,0.5293,0.4707,RH,RH
 2018-03-02,Roberto Bautista Agut,Malek Jaziri,0.5288,0.4713,RH,RH
-2018-03-12,Juan Martin Del Potro,Alex De Minaur,0.7044,0.2956,RH,LH
-2018-03-12,Roger Federer,Filip Krajinovic,0.6507,0.3493,LH,LH
-2018-03-12,Pablo Carreno Busta,Daniil Medvedev,0.4356,0.5644,LH,RH
+2018-03-12,Juan Martin Del Potro,Alex De Minaur,0.7044,0.2956,RH,RH
+2018-03-12,Roger Federer,Filip Krajinovic,0.6507,0.3493,RH,RH
+2018-03-12,Pablo Carreno Busta,Daniil Medvedev,0.4356,0.5644,RH,RH
 2018-03-12,Borna Coric,Roberto Bautista Agut,0.3184,0.6816,RH,RH
-2018-03-13,Juan Martin Del Potro,David Ferrer,0.7067,0.2933,RH,LH
-2018-03-14,Kevin Anderson,Pablo Carreno Busta,0.6568,0.3431,LH,LH
-2018-03-16,Juan Martin Del Potro,Philipp Kohlschreiber,0.6082,0.3918,LH,RH
+2018-03-13,Juan Martin Del Potro,David Ferrer,0.7067,0.2933,RH,RH
+2018-03-14,Kevin Anderson,Pablo Carreno Busta,0.6568,0.3431,RH,RH
+2018-03-16,Juan Martin Del Potro,Philipp Kohlschreiber,0.6082,0.3918,RH,RH
 2018-03-17,Juan Martin Del Potro,Milos Raonic,0.4883,0.5118,RH,RH
-2018-03-18,Juan Martin Del Potro,Roger Federer,0.3414,0.6586,RH,LH
-2018-03-24,Alexander Zverev,Daniil Medvedev,0.5194,0.4806,LH,LH
-2018-03-25,Juan Martin Del Potro,Kei Nishikori,0.5986,0.4014,LH,RH
+2018-03-18,Juan Martin Del Potro,Roger Federer,0.3414,0.6586,RH,RH
+2018-03-24,Alexander Zverev,Daniil Medvedev,0.5194,0.4806,RH,RH
+2018-03-25,Juan Martin Del Potro,Kei Nishikori,0.5986,0.4014,RH,RH
 2018-03-26,Milos Raonic,Diego Schwartzman,0.736,0.264,RH,RH
-2018-03-26,Pablo Carreno Busta,Steve Johnson,0.3966,0.6034,RH,LH
-2018-03-28,Alexander Zverev,Nick Kyrgios,0.4511,0.5489,LH,LH
-2018-03-29,Juan Martin Del Potro,Milos Raonic,0.4919,0.5081,LH,RH
+2018-03-26,Pablo Carreno Busta,Steve Johnson,0.3966,0.6034,RH,RH
+2018-03-28,Alexander Zverev,Nick Kyrgios,0.4511,0.5489,RH,RH
+2018-03-29,Juan Martin Del Potro,Milos Raonic,0.4919,0.5081,RH,RH
 2018-03-29,Pablo Carreno Busta,Kevin Anderson,0.3431,0.6568,RH,RH
-2018-03-30,Alexander Zverev,Borna Coric,0.6407,0.3593,RH,LH
-2018-03-30,John Isner,Juan Martin Del Potro,0.5998,0.4002,LH,LH
-2018-04-16,Kei Nishikori,Tomas Berdych,0.5077,0.4923,LH,RH
+2018-03-30,Alexander Zverev,Borna Coric,0.6407,0.3593,RH,RH
+2018-03-30,John Isner,Juan Martin Del Potro,0.5998,0.4002,RH,RH
+2018-04-16,Kei Nishikori,Tomas Berdych,0.5077,0.4923,RH,RH
 2018-04-17,Jan Lennard Struff,Yuichi Sugita,0.7556,0.2444,RH,RH
-2018-04-17,Dominic Thiem,Andrey Rublev,0.5087,0.4913,RH,LH
-2018-04-19,David Goffin,Roberto Bautista Agut,0.4778,0.5222,LH,LH
-2018-04-19,Dominic Thiem,Novak Djokovic,0.4637,0.5363,LH,RH
+2018-04-17,Dominic Thiem,Andrey Rublev,0.5087,0.4913,RH,RH
+2018-04-19,David Goffin,Roberto Bautista Agut,0.4778,0.5222,RH,RH
+2018-04-19,Dominic Thiem,Novak Djokovic,0.4637,0.5363,RH,RH
 2018-04-20,Grigor Dimitrov,David Goffin,0.477,0.523,RH,RH
-2018-04-21,Kei Nishikori,Alexander Zverev,0.5249,0.4752,RH,LH
-2018-04-25,Grigor Dimitrov,Gilles Simon,0.6025,0.3975,LH,LH
-2018-04-25,Pablo Carreno Busta,Benoit Paire,0.4602,0.5397,LH,RH
+2018-04-21,Kei Nishikori,Alexander Zverev,0.5249,0.4752,RH,RH
+2018-04-25,Grigor Dimitrov,Gilles Simon,0.6025,0.3975,RH,RH
+2018-04-25,Pablo Carreno Busta,Benoit Paire,0.4602,0.5397,RH,RH
 2018-04-27,Pablo Carreno Busta,Grigor Dimitrov,0.4012,0.5988,RH,RH
-2018-04-27,David Goffin,Roberto Bautista Agut,0.4737,0.5263,RH,LH
-2018-05-01,Mirza Basic,Gael Monfils,0.5244,0.4756,LH,LH
-2018-05-06,Richard Gasquet,Tomas Berdych,0.4528,0.5472,LH,RH
+2018-04-27,David Goffin,Roberto Bautista Agut,0.4737,0.5263,RH,RH
+2018-05-01,Mirza Basic,Gael Monfils,0.5244,0.4756,RH,RH
+2018-05-06,Richard Gasquet,Tomas Berdych,0.4528,0.5472,RH,RH
 2018-05-07,Novak Djokovic,Kei Nishikori,0.5914,0.4086,RH,RH
-2018-05-08,Borna Coric,Pablo Carreno Busta,0.4254,0.5746,RH,LH
-2018-05-08,Milos Raonic,Grigor Dimitrov,0.6185,0.3814,LH,LH
-2018-05-08,Juan Martin Del Potro,Damir Dzumhur,0.7369,0.2631,LH,RH
+2018-05-08,Borna Coric,Pablo Carreno Busta,0.4254,0.5746,RH,RH
+2018-05-08,Milos Raonic,Grigor Dimitrov,0.6185,0.3814,RH,RH
+2018-05-08,Juan Martin Del Potro,Damir Dzumhur,0.7369,0.2631,RH,RH
 2018-05-13,Alexander Zverev,Dominic Thiem,0.5265,0.4735,RH,RH
-2018-05-14,Philipp Kohlschreiber,Karen Khachanov,0.505,0.495,RH,LH
-2018-05-15,David Goffin,Marco Cecchinato,0.5288,0.4713,LH,LH
-2018-05-16,Pablo Carreno Busta,Steve Johnson,0.3543,0.6458,LH,RH
+2018-05-14,Philipp Kohlschreiber,Karen Khachanov,0.505,0.495,RH,RH
+2018-05-15,David Goffin,Marco Cecchinato,0.5288,0.4713,RH,RH
+2018-05-16,Pablo Carreno Busta,Steve Johnson,0.3543,0.6458,RH,RH
 2018-05-17,Pablo Carreno Busta,Aljaz Bedene,0.5528,0.4472,RH,RH
-2018-05-17,David Goffin,Juan Martin Del Potro,0.4073,0.5927,RH,LH
-2018-05-18,Marin Cilic,Pablo Carreno Busta,0.581,0.419,LH,LH
-2018-05-18,Novak Djokovic,Kei Nishikori,0.6028,0.3972,LH,RH
+2018-05-17,David Goffin,Juan Martin Del Potro,0.4073,0.5927,RH,RH
+2018-05-18,Marin Cilic,Pablo Carreno Busta,0.581,0.419,RH,RH
+2018-05-18,Novak Djokovic,Kei Nishikori,0.6028,0.3972,RH,RH
 2018-05-18,Alexander Zverev,David Goffin,0.5222,0.4778,RH,RH
-2018-05-26,Dominic Thiem,Gilles Simon,0.4562,0.5438,RH,LH
-2018-05-30,Kei Nishikori,Benoit Paire,0.5641,0.4358,LH,LH
-2018-06-02,Karen Khachanov,Lucas Pouille,0.509,0.491,LH,RH
+2018-05-26,Dominic Thiem,Gilles Simon,0.4562,0.5438,RH,RH
+2018-05-30,Kei Nishikori,Benoit Paire,0.5641,0.4358,RH,RH
+2018-06-02,Karen Khachanov,Lucas Pouille,0.509,0.491,RH,RH
 2018-06-04,Diego Schwartzman,Kevin Anderson,0.3537,0.6463,RH,RH
-2018-06-04,Juan Martin Del Potro,John Isner,0.4315,0.5684,RH,LH
-2018-06-05,Marco Cecchinato,Novak Djokovic,0.5017,0.4983,LH,LH
-2018-06-07,Juan Martin Del Potro,Marin Cilic,0.5635,0.4365,LH,RH
+2018-06-04,Juan Martin Del Potro,John Isner,0.4315,0.5684,RH,RH
+2018-06-05,Marco Cecchinato,Novak Djokovic,0.5017,0.4983,RH,RH
+2018-06-07,Juan Martin Del Potro,Marin Cilic,0.5635,0.4365,RH,RH
 2018-06-10,Rafael Nadal,Dominic Thiem,0.6742,0.3258,RH,RH
-2018-06-13,Milos Raonic,Mirza Basic,0.5555,0.4445,RH,LH
-2018-06-16,Roger Federer,Nick Kyrgios,0.5949,0.4052,LH,LH
-2018-06-17,Roger Federer,Milos Raonic,0.6105,0.3895,LH,RH
+2018-06-13,Milos Raonic,Mirza Basic,0.5555,0.4445,RH,RH
+2018-06-16,Roger Federer,Nick Kyrgios,0.5949,0.4052,RH,RH
+2018-06-17,Roger Federer,Milos Raonic,0.6105,0.3895,RH,RH
 2018-06-21,Roger Federer,Benoit Paire,0.7101,0.2899,RH,RH
-2018-06-22,Roger Federer,Matthew Ebden,0.5256,0.4744,RH,LH
-2018-06-23,Borna Coric,Roberto Bautista Agut,0.4136,0.5864,LH,LH
-2018-06-19,Nick Kyrgios,Andy Murray,0.6029,0.3971,LH,RH
+2018-06-22,Roger Federer,Matthew Ebden,0.5256,0.4744,RH,RH
+2018-06-23,Borna Coric,Roberto Bautista Agut,0.4136,0.5864,RH,RH
+2018-06-19,Nick Kyrgios,Andy Murray,0.6029,0.3971,RH,RH
 2018-06-22,Marin Cilic,Sam Querrey,0.5047,0.4954,RH,RH
-2018-06-23,Marin Cilic,Nick Kyrgios,0.4134,0.5865,RH,LH
-2018-06-24,Marin Cilic,Novak Djokovic,0.5411,0.4589,LH,LH
-2018-06-25,Andy Murray,Stan Wawrinka,0.5548,0.4453,LH,RH
+2018-06-23,Marin Cilic,Nick Kyrgios,0.4134,0.5865,RH,RH
+2018-06-24,Marin Cilic,Novak Djokovic,0.5411,0.4589,RH,RH
+2018-06-25,Andy Murray,Stan Wawrinka,0.5548,0.4453,RH,RH
 2018-07-03,Juan Martin Del Potro,Peter Gojowczyk,0.6702,0.3298,RH,RH
-2018-07-07,Juan Martin Del Potro,Benoit Paire,0.626,0.374,RH,LH
-2018-07-09,Novak Djokovic,Karen Khachanov,0.4803,0.5197,LH,LH
-2018-07-10,Juan Martin Del Potro,Gilles Simon,0.7488,0.2512,LH,RH
+2018-07-07,Juan Martin Del Potro,Benoit Paire,0.626,0.374,RH,RH
+2018-07-09,Novak Djokovic,Karen Khachanov,0.4803,0.5197,RH,RH
+2018-07-10,Juan Martin Del Potro,Gilles Simon,0.7488,0.2512,RH,RH
 2018-07-11,Novak Djokovic,Kei Nishikori,0.6041,0.3959,RH,RH
-2018-07-11,Kevin Anderson,Roger Federer,0.3936,0.6063,RH,LH
-2018-07-13,Kevin Anderson,John Isner,0.4368,0.5632,LH,LH
-2018-07-26,John Isner,Alex De Minaur,0.7772,0.2228,LH,RH
+2018-07-11,Kevin Anderson,Roger Federer,0.3936,0.6063,RH,RH
+2018-07-13,Kevin Anderson,John Isner,0.4368,0.5632,RH,RH
+2018-07-26,John Isner,Alex De Minaur,0.7772,0.2228,RH,RH
 2018-07-29,John Isner,Ryan Harrison,0.6726,0.3274,RH,RH
-2018-07-26,Pablo Carreno Busta,Aljaz Bedene,0.5153,0.4847,RH,LH
-2018-07-27,Nicolas Jarry,Dominic Thiem,0.6273,0.3727,LH,LH
-2018-07-27,Nikoloz Basilashvili,Pablo Carreno Busta,0.4226,0.5774,LH,RH
+2018-07-26,Pablo Carreno Busta,Aljaz Bedene,0.5153,0.4847,RH,RH
+2018-07-27,Nicolas Jarry,Dominic Thiem,0.6273,0.3727,RH,RH
+2018-07-27,Nikoloz Basilashvili,Pablo Carreno Busta,0.4226,0.5774,RH,RH
 2018-08-04,Juan Martin Del Potro,Damir Dzumhur,0.7279,0.2721,RH,RH
-2018-08-05,Fabio Fognini,Juan Martin Del Potro,0.2865,0.7135,RH,LH
-2018-08-02,Alexander Zverev,Malek Jaziri,0.5307,0.4693,LH,LH
-2018-08-04,Alexander Zverev,Kei Nishikori,0.6251,0.3749,LH,RH
+2018-08-05,Fabio Fognini,Juan Martin Del Potro,0.2865,0.7135,RH,RH
+2018-08-02,Alexander Zverev,Malek Jaziri,0.5307,0.4693,RH,RH
+2018-08-04,Alexander Zverev,Kei Nishikori,0.6251,0.3749,RH,RH
 2018-08-05,Alex De Minaur,Andrey Rublev,0.4655,0.5345,RH,RH
-2018-08-07,Stan Wawrinka,Nick Kyrgios,0.3464,0.6535,RH,LH
-2018-08-07,Stefanos Tsitsipas,Damir Dzumhur,0.6317,0.3683,LH,LH
-2018-08-08,Karen Khachanov,Pablo Carreno Busta,0.595,0.405,LH,RH
+2018-08-07,Stan Wawrinka,Nick Kyrgios,0.3464,0.6535,RH,RH
+2018-08-07,Stefanos Tsitsipas,Damir Dzumhur,0.6317,0.3683,RH,RH
+2018-08-08,Karen Khachanov,Pablo Carreno Busta,0.595,0.405,RH,RH
 2018-08-09,Stefanos Tsitsipas,Novak Djokovic,0.5272,0.4728,RH,RH
-2018-08-09,Marin Cilic,Diego Schwartzman,0.6127,0.3873,RH,LH
-2018-08-13,Pablo Carreno Busta,Richard Gasquet,0.4227,0.5773,LH,LH
-2018-08-14,David Goffin,Stefanos Tsitsipas,0.4516,0.5484,LH,RH
+2018-08-09,Marin Cilic,Diego Schwartzman,0.6127,0.3873,RH,RH
+2018-08-13,Pablo Carreno Busta,Richard Gasquet,0.4227,0.5773,RH,RH
+2018-08-14,David Goffin,Stefanos Tsitsipas,0.4516,0.5484,RH,RH
 2018-08-15,Roger Federer,Peter Gojowczyk,0.7367,0.2633,RH,RH
-2018-08-15,Karen Khachanov,Sam Querrey,0.4899,0.5101,RH,LH
-2018-08-16,Stan Wawrinka,Kei Nishikori,0.478,0.522,LH,LH
-2018-08-17,Juan Martin Del Potro,Nick Kyrgios,0.5133,0.4867,LH,RH
+2018-08-15,Karen Khachanov,Sam Querrey,0.4899,0.5101,RH,RH
+2018-08-16,Stan Wawrinka,Kei Nishikori,0.478,0.522,RH,RH
+2018-08-17,Juan Martin Del Potro,Nick Kyrgios,0.5133,0.4867,RH,RH
 2018-08-17,David Goffin,Kevin Anderson,0.2607,0.7393,RH,RH
-2018-08-17,Novak Djokovic,Grigor Dimitrov,0.6396,0.3604,RH,LH
-2018-08-17,Roger Federer,Leonardo Mayer,0.7126,0.2874,LH,LH
-2018-08-17,Marin Cilic,Pablo Carreno Busta,0.5986,0.4014,LH,RH
+2018-08-17,Novak Djokovic,Grigor Dimitrov,0.6396,0.3604,RH,RH
+2018-08-17,Roger Federer,Leonardo Mayer,0.7126,0.2874,RH,RH
+2018-08-17,Marin Cilic,Pablo Carreno Busta,0.5986,0.4014,RH,RH
 2018-08-18,David Goffin,Juan Martin Del Potro,0.3863,0.6137,RH,RH
-2018-08-18,Roger Federer,Stan Wawrinka,0.7199,0.2801,RH,LH
-2018-08-18,Novak Djokovic,Marin Cilic,0.4922,0.5077,LH,LH
-2018-08-25,Steve Johnson,Pablo Carreno Busta,0.6662,0.3338,LH,RH
+2018-08-18,Roger Federer,Stan Wawrinka,0.7199,0.2801,RH,RH
+2018-08-18,Novak Djokovic,Marin Cilic,0.4922,0.5077,RH,RH
+2018-08-25,Steve Johnson,Pablo Carreno Busta,0.6662,0.3338,RH,RH
 2018-08-27,Stan Wawrinka,Grigor Dimitrov,0.3907,0.6093,RH,RH
-2018-08-27,Kevin Anderson,Ryan Harrison,0.53,0.47,RH,LH
-2018-09-01,Milos Raonic,Stan Wawrinka,0.719,0.281,LH,LH
-2018-09-01,Juan Martin Del Potro,Fernando Verdasco,0.6798,0.3202,LH,RH
+2018-08-27,Kevin Anderson,Ryan Harrison,0.53,0.47,RH,RH
+2018-09-01,Milos Raonic,Stan Wawrinka,0.719,0.281,RH,RH
+2018-09-01,Juan Martin Del Potro,Fernando Verdasco,0.6798,0.3202,RH,RH
 2018-09-01,Roger Federer,Nick Kyrgios,0.5906,0.4094,RH,RH
-2018-09-02,Dominic Thiem,Kevin Anderson,0.3103,0.6898,RH,LH
-2018-09-03,Juan Martin Del Potro,Borna Coric,0.6209,0.3791,LH,LH
-2018-09-03,Marin Cilic,David Goffin,0.4494,0.5506,LH,RH
+2018-09-02,Dominic Thiem,Kevin Anderson,0.3103,0.6898,RH,RH
+2018-09-03,Juan Martin Del Potro,Borna Coric,0.6209,0.3791,RH,RH
+2018-09-03,Marin Cilic,David Goffin,0.4494,0.5506,RH,RH
 2018-09-04,Juan Martin Del Potro,John Isner,0.3992,0.6008,RH,RH
-2018-09-05,Rafael Nadal,Dominic Thiem,0.6843,0.3157,RH,LH
-2018-09-08,Novak Djokovic,Kei Nishikori,0.5989,0.4011,LH,LH
-2018-09-09,Novak Djokovic,Juan Martin Del Potro,0.4526,0.5474,LH,RH
+2018-09-05,Rafael Nadal,Dominic Thiem,0.6843,0.3157,RH,RH
+2018-09-08,Novak Djokovic,Kei Nishikori,0.5989,0.4011,RH,RH
+2018-09-09,Novak Djokovic,Juan Martin Del Potro,0.4526,0.5474,RH,RH
 2018-09-18,Peter Gojowczyk,Jo Wilfried Tsonga,0.3269,0.673,RH,RH
-2018-09-21,Gilles Simon,Richard Gasquet,0.4434,0.5566,RH,LH
-2018-09-21,Kei Nishikori,Nikoloz Basilashvili,0.5711,0.4289,LH,LH
-2018-09-22,Dominic Thiem,Roberto Bautista Agut,0.503,0.497,LH,RH
+2018-09-21,Gilles Simon,Richard Gasquet,0.4434,0.5566,RH,RH
+2018-09-21,Kei Nishikori,Nikoloz Basilashvili,0.5711,0.4289,RH,RH
+2018-09-22,Dominic Thiem,Roberto Bautista Agut,0.503,0.497,RH,RH
 2018-09-25,Alex De Minaur,Yuichi Sugita,0.5787,0.4213,RH,RH
-2018-09-27,Andy Murray,David Goffin,0.451,0.549,RH,LH
-2018-09-28,Alex De Minaur,Damir Dzumhur,0.6431,0.3569,LH,LH
-2018-10-01,Karen Khachanov,Sam Querrey,0.5186,0.4814,LH,RH
+2018-09-27,Andy Murray,David Goffin,0.451,0.549,RH,RH
+2018-09-28,Alex De Minaur,Damir Dzumhur,0.6431,0.3569,RH,RH
+2018-10-01,Karen Khachanov,Sam Querrey,0.5186,0.4814,RH,RH
 2018-10-02,Andrey Rublev,Joao Sousa,0.5403,0.4597,RH,RH
-2018-10-03,Juan Martin Del Potro,Karen Khachanov,0.6089,0.3911,RH,LH
-2018-10-04,Fabio Fognini,Andrey Rublev,0.3754,0.6247,LH,LH
-2018-10-06,Juan Martin Del Potro,Fabio Fognini,0.7196,0.2804,LH,RH
+2018-10-03,Juan Martin Del Potro,Karen Khachanov,0.6089,0.3911,RH,RH
+2018-10-04,Fabio Fognini,Andrey Rublev,0.3754,0.6247,RH,RH
+2018-10-06,Juan Martin Del Potro,Fabio Fognini,0.7196,0.2804,RH,RH
 2018-10-07,Nikoloz Basilashvili,Juan Martin Del Potro,0.3034,0.6966,RH,RH
-2018-10-04,Richard Gasquet,Nick Kyrgios,0.375,0.625,RH,LH
-2018-10-05,Kei Nishikori,Stefanos Tsitsipas,0.3817,0.6183,LH,LH
-2018-10-09,Benoit Paire,Pablo Carreno Busta,0.5289,0.4711,LH,RH
+2018-10-04,Richard Gasquet,Nick Kyrgios,0.375,0.625,RH,RH
+2018-10-05,Kei Nishikori,Stefanos Tsitsipas,0.3817,0.6183,RH,RH
+2018-10-09,Benoit Paire,Pablo Carreno Busta,0.5289,0.4711,RH,RH
 2018-10-10,Alexander Zverev,Nikoloz Basilashvili,0.625,0.375,RH,RH
-2018-10-10,Alex De Minaur,Benoit Paire,0.4383,0.5617,RH,LH
-2018-10-10,Juan Martin Del Potro,Richard Gasquet,0.6238,0.3762,LH,LH
-2018-10-10,Roger Federer,Daniil Medvedev,0.7087,0.2913,LH,RH
+2018-10-10,Alex De Minaur,Benoit Paire,0.4383,0.5617,RH,RH
+2018-10-10,Juan Martin Del Potro,Richard Gasquet,0.6238,0.3762,RH,RH
+2018-10-10,Roger Federer,Daniil Medvedev,0.7087,0.2913,RH,RH
 2018-10-11,Alexander Zverev,Alex De Minaur,0.6754,0.3246,RH,RH
-2018-10-11,Kevin Anderson,Stefanos Tsitsipas,0.681,0.319,RH,LH
-2018-10-11,Borna Coric,Juan Martin Del Potro,0.3569,0.6431,LH,LH
-2018-10-12,Roger Federer,Kei Nishikori,0.7519,0.248,LH,RH
+2018-10-11,Kevin Anderson,Stefanos Tsitsipas,0.681,0.319,RH,RH
+2018-10-11,Borna Coric,Juan Martin Del Potro,0.3569,0.6431,RH,RH
+2018-10-12,Roger Federer,Kei Nishikori,0.7519,0.248,RH,RH
 2018-10-13,Novak Djokovic,Alexander Zverev,0.4424,0.5576,RH,RH
-2018-10-14,Novak Djokovic,Borna Coric,0.5559,0.4441,RH,LH
-2018-10-19,Richard Gasquet,Jan Lennard Struff,0.4461,0.5539,LH,LH
-2018-10-18,Mirza Basic,Nick Kyrgios,0.5074,0.4926,LH,RH
+2018-10-14,Novak Djokovic,Borna Coric,0.5559,0.4441,RH,RH
+2018-10-19,Richard Gasquet,Jan Lennard Struff,0.4461,0.5539,RH,RH
+2018-10-18,Mirza Basic,Nick Kyrgios,0.5074,0.4926,RH,RH
 2018-10-19,Karen Khachanov,Mirza Basic,0.4262,0.5738,RH,RH
-2018-10-26,Roger Federer,Gilles Simon,0.7311,0.2689,RH,LH
-2018-10-26,Daniil Medvedev,Stefanos Tsitsipas,0.4177,0.5822,LH,LH
-2018-10-27,Roger Federer,Daniil Medvedev,0.7193,0.2807,LH,RH
+2018-10-26,Roger Federer,Gilles Simon,0.7311,0.2689,RH,RH
+2018-10-26,Daniil Medvedev,Stefanos Tsitsipas,0.4177,0.5822,RH,RH
+2018-10-27,Roger Federer,Daniil Medvedev,0.7193,0.2807,RH,RH
 2018-10-28,Roger Federer,Marius Copil,0.5289,0.4711,RH,RH
-2018-10-23,Sam Querrey,Jo Wilfried Tsonga,0.4753,0.5247,RH,LH
-2018-10-26,Kei Nishikori,Dominic Thiem,0.3365,0.6636,LH,LH
-2018-10-28,Kevin Anderson,Kei Nishikori,0.6627,0.3373,LH,RH
+2018-10-23,Sam Querrey,Jo Wilfried Tsonga,0.4753,0.5247,RH,RH
+2018-10-26,Kei Nishikori,Dominic Thiem,0.3365,0.6636,RH,RH
+2018-10-28,Kevin Anderson,Kei Nishikori,0.6627,0.3373,RH,RH
 2018-10-29,Nikoloz Basilashvili,John Millman,0.4628,0.5372,RH,RH
-2018-10-29,Joao Sousa,Marco Cecchinato,0.4701,0.5299,RH,LH
-2018-10-30,Daniil Medvedev,Pablo Carreno Busta,0.5384,0.4616,LH,LH
-2018-10-30,Damir Dzumhur,Stefanos Tsitsipas,0.3288,0.6711,LH,RH
+2018-10-29,Joao Sousa,Marco Cecchinato,0.4701,0.5299,RH,RH
+2018-10-30,Daniil Medvedev,Pablo Carreno Busta,0.5384,0.4616,RH,RH
+2018-10-30,Damir Dzumhur,Stefanos Tsitsipas,0.3288,0.6711,RH,RH
 2018-10-30,Marin Cilic,Philipp Kohlschreiber,0.5724,0.4276,RH,RH
-2018-10-31,Dominic Thiem,Gilles Simon,0.4285,0.5715,RH,LH
-2018-11-01,Alexander Zverev,Diego Schwartzman,0.6349,0.3651,LH,LH
-2018-11-01,Dominic Thiem,Borna Coric,0.5638,0.4362,LH,RH
+2018-10-31,Dominic Thiem,Gilles Simon,0.4285,0.5715,RH,RH
+2018-11-01,Alexander Zverev,Diego Schwartzman,0.6349,0.3651,RH,RH
+2018-11-01,Dominic Thiem,Borna Coric,0.5638,0.4362,RH,RH
 2018-11-01,Roger Federer,Fabio Fognini,0.7535,0.2465,RH,RH
-2018-11-01,Kei Nishikori,Kevin Anderson,0.3319,0.6681,RH,LH
-2018-11-02,Dominic Thiem,Jack Sock,0.5859,0.4141,LH,LH
-2018-11-02,Novak Djokovic,Marin Cilic,0.4945,0.5055,LH,RH
+2018-11-01,Kei Nishikori,Kevin Anderson,0.3319,0.6681,RH,RH
+2018-11-02,Dominic Thiem,Jack Sock,0.5859,0.4141,RH,RH
+2018-11-02,Novak Djokovic,Marin Cilic,0.4945,0.5055,RH,RH
 2018-11-02,Roger Federer,Kei Nishikori,0.7428,0.2572,RH,RH
-2018-11-03,Karen Khachanov,Dominic Thiem,0.3892,0.6107,RH,LH
-2018-11-04,Karen Khachanov,Novak Djokovic,0.5004,0.4995,LH,LH
-2018-11-11,Kevin Anderson,Dominic Thiem,0.5535,0.4465,LH,RH
+2018-11-03,Karen Khachanov,Dominic Thiem,0.3892,0.6107,RH,RH
+2018-11-04,Karen Khachanov,Novak Djokovic,0.5004,0.4995,RH,RH
+2018-11-11,Kevin Anderson,Dominic Thiem,0.5535,0.4465,RH,RH
 2018-11-11,Kei Nishikori,Roger Federer,0.2572,0.7428,RH,RH
-2018-11-12,Novak Djokovic,John Isner,0.3271,0.6729,RH,LH
-2018-11-13,Kevin Anderson,Kei Nishikori,0.6711,0.3289,LH,LH
-2018-11-14,Novak Djokovic,Alexander Zverev,0.4997,0.5003,LH,RH
+2018-11-12,Novak Djokovic,John Isner,0.3271,0.6729,RH,RH
+2018-11-13,Kevin Anderson,Kei Nishikori,0.6711,0.3289,RH,RH
+2018-11-14,Novak Djokovic,Alexander Zverev,0.4997,0.5003,RH,RH
 2018-11-15,Dominic Thiem,Kei Nishikori,0.66,0.34,RH,RH
-2018-11-16,Alexander Zverev,John Isner,0.4456,0.5544,RH,LH
-2018-11-16,Novak Djokovic,Marin Cilic,0.4894,0.5106,LH,LH
-2018-11-17,Alexander Zverev,Roger Federer,0.2777,0.7224,LH,RH
+2018-11-16,Alexander Zverev,John Isner,0.4456,0.5544,RH,RH
+2018-11-16,Novak Djokovic,Marin Cilic,0.4894,0.5106,RH,RH
+2018-11-17,Alexander Zverev,Roger Federer,0.2777,0.7224,RH,RH
 2018-11-18,Alexander Zverev,Novak Djokovic,0.5003,0.4997,RH,RH
-2018-01-01,Elina Svitolina,Carla Suarez Navarro,0.6811,0.3189,RH,LH
-2018-01-01,Anett Kontaveit,Heather Watson,0.591,0.409,LH,LH
-2018-01-02,Anastasija Sevastova,Sorana Cirstea,0.5033,0.4967,LH,RH
+2018-01-01,Elina Svitolina,Carla Suarez Navarro,0.6811,0.3189,RH,RH
+2018-01-01,Anett Kontaveit,Heather Watson,0.591,0.409,RH,RH
+2018-01-02,Anastasija Sevastova,Sorana Cirstea,0.5033,0.4967,RH,RH
 2018-01-03,Karolina Pliskova,Catherine Cartan Bellis,0.6576,0.3424,RH,RH
-2018-01-04,Aliaksandra Sasnovich,Alize Cornet,0.536,0.464,RH,LH
-2018-01-04,Elina Svitolina,Johanna Konta,0.4912,0.5088,LH,LH
-2018-01-05,Elina Svitolina,Karolina Pliskova,0.4516,0.5484,LH,RH
+2018-01-04,Aliaksandra Sasnovich,Alize Cornet,0.536,0.464,RH,RH
+2018-01-04,Elina Svitolina,Johanna Konta,0.4912,0.5088,RH,RH
+2018-01-05,Elina Svitolina,Karolina Pliskova,0.4516,0.5484,RH,RH
 2017-12-31,Alison Riske Amritraj,Qiang Wang,0.5113,0.4887,RH,RH
-2017-12-31,Aryna Sabalenka,Monica Niculescu,0.748,0.252,RH,LH
-2018-01-01,Simona Halep,Nicole Gibbs,0.5514,0.4486,LH,LH
-2018-01-02,Karolina Pliskova,Jelena Ostapenko,0.5682,0.4318,LH,RH
+2017-12-31,Aryna Sabalenka,Monica Niculescu,0.748,0.252,RH,RH
+2018-01-01,Simona Halep,Nicole Gibbs,0.5514,0.4486,RH,RH
+2018-01-02,Karolina Pliskova,Jelena Ostapenko,0.5682,0.4318,RH,RH
 2018-01-02,Zarina Diyas,Shuai Zhang,0.458,0.542,RH,RH
-2018-01-02,Aryna Sabalenka,Danka Kovinic,0.7281,0.272,RH,LH
-2018-01-04,Katerina Siniakova,Karolina Pliskova,0.3606,0.6394,LH,LH
-2018-01-06,Simona Halep,Katerina Siniakova,0.5823,0.4177,LH,RH
+2018-01-02,Aryna Sabalenka,Danka Kovinic,0.7281,0.272,RH,RH
+2018-01-04,Katerina Siniakova,Karolina Pliskova,0.3606,0.6394,RH,RH
+2018-01-06,Simona Halep,Katerina Siniakova,0.5823,0.4177,RH,RH
 2018-01-08,Lesia Tsurenko,Timea Babos,0.3713,0.6287,RH,RH
-2018-01-08,Aryna Sabalenka,Eugenie Bouchard,0.6198,0.3802,RH,LH
-2018-01-09,Alison Riske Amritraj,Katerina Siniakova,0.4725,0.5275,LH,LH
-2018-01-10,Aryna Sabalenka,Shuai Zhang,0.6947,0.3053,LH,RH
+2018-01-08,Aryna Sabalenka,Eugenie Bouchard,0.6198,0.3802,RH,RH
+2018-01-09,Alison Riske Amritraj,Katerina Siniakova,0.4725,0.5275,RH,RH
+2018-01-10,Aryna Sabalenka,Shuai Zhang,0.6947,0.3053,RH,RH
 2018-01-11,Elise Mertens,Monica Niculescu,0.4617,0.5383,RH,RH
-2018-01-08,Dominika Cibulkova,Anastasija Sevastova,0.4831,0.5169,RH,LH
-2018-01-08,Catherine Cartan Bellis,Magdalena Rybarikova,0.4123,0.5877,LH,LH
-2018-01-09,Agnieszka Radwanska,Johanna Konta,0.5341,0.4658,LH,RH
+2018-01-08,Dominika Cibulkova,Anastasija Sevastova,0.4831,0.5169,RH,RH
+2018-01-08,Catherine Cartan Bellis,Magdalena Rybarikova,0.4123,0.5877,RH,RH
+2018-01-09,Agnieszka Radwanska,Johanna Konta,0.5341,0.4658,RH,RH
 2018-01-10,Garbine Muguruza,Kiki Bertens,0.5923,0.4077,RH,RH
-2018-01-11,Angelique Kerber,Dominika Cibulkova,0.537,0.463,RH,LH
-2018-01-15,Kiki Bertens,Catherine Cartan Bellis,0.5615,0.4385,LH,LH
-2018-01-15,Monica Puig,Samantha Stosur,0.4445,0.5555,LH,RH
+2018-01-11,Angelique Kerber,Dominika Cibulkova,0.537,0.463,RH,RH
+2018-01-15,Kiki Bertens,Catherine Cartan Bellis,0.5615,0.4385,RH,RH
+2018-01-15,Monica Puig,Samantha Stosur,0.4445,0.5555,RH,RH
 2018-01-16,Lesia Tsurenko,Natalia Vikhlyantseva,0.3402,0.6598,RH,RH
-2018-01-16,Agnieszka Radwanska,Karolina Pliskova,0.3729,0.6271,RH,LH
-2018-01-17,Elina Svitolina,Katerina Siniakova,0.5851,0.4149,LH,LH
-2018-01-17,Carla Suarez Navarro,Timea Babos,0.5927,0.4073,LH,RH
+2018-01-16,Agnieszka Radwanska,Karolina Pliskova,0.3729,0.6271,RH,RH
+2018-01-17,Elina Svitolina,Katerina Siniakova,0.5851,0.4149,RH,RH
+2018-01-17,Carla Suarez Navarro,Timea Babos,0.5927,0.4073,RH,RH
 2018-01-18,Agnieszka Radwanska,Lesia Tsurenko,0.6624,0.3376,RH,RH
-2018-01-19,Caroline Wozniacki,Kiki Bertens,0.4612,0.5388,RH,LH
-2018-01-22,Madison Keys,Caroline Garcia,0.4586,0.5414,LH,LH
-2018-01-22,Simona Halep,Naomi Osaka,0.6461,0.3539,LH,RH
+2018-01-19,Caroline Wozniacki,Kiki Bertens,0.4612,0.5388,RH,RH
+2018-01-22,Madison Keys,Caroline Garcia,0.4586,0.5414,RH,RH
+2018-01-22,Simona Halep,Naomi Osaka,0.6461,0.3539,RH,RH
 2018-01-22,Karolina Pliskova,Barbora Strycova,0.7661,0.2339,RH,RH
-2018-01-24,Simona Halep,Karolina Pliskova,0.4014,0.5985,RH,LH
-2018-01-25,Simona Halep,Angelique Kerber,0.3878,0.6122,LH,LH
-2018-01-27,Caroline Wozniacki,Simona Halep,0.5502,0.4498,LH,RH
+2018-01-24,Simona Halep,Karolina Pliskova,0.4014,0.5985,RH,RH
+2018-01-25,Simona Halep,Angelique Kerber,0.3878,0.6122,RH,RH
+2018-01-27,Caroline Wozniacki,Simona Halep,0.5502,0.4498,RH,RH
 2018-01-30,Dominika Cibulkova,Sorana Cirstea,0.6687,0.3313,RH,RH
-2018-02-01,Kristina Mladenovic,Dominika Cibulkova,0.4662,0.5338,RH,LH
-2018-02-02,Daria Kasatkina,Caroline Wozniacki,0.2369,0.7631,LH,LH
-2018-02-03,Kristina Mladenovic,Daria Kasatkina,0.5682,0.4318,LH,RH
+2018-02-01,Kristina Mladenovic,Dominika Cibulkova,0.4662,0.5338,RH,RH
+2018-02-02,Daria Kasatkina,Caroline Wozniacki,0.2369,0.7631,RH,RH
+2018-02-03,Kristina Mladenovic,Daria Kasatkina,0.5682,0.4318,RH,RH
 2018-01-30,Nao Hibino,Samantha Stosur,0.2085,0.7915,RH,RH
-2018-02-12,Catherine Cartan Bellis,Daria Kasatkina,0.4961,0.5039,RH,LH
-2018-02-13,Samantha Stosur,Irina Camelia Begu,0.5317,0.4682,LH,LH
-2018-02-13,Carla Suarez Navarro,Kateryna Bondarenko,0.6039,0.3961,LH,RH
+2018-02-12,Catherine Cartan Bellis,Daria Kasatkina,0.4961,0.5039,RH,RH
+2018-02-13,Samantha Stosur,Irina Camelia Begu,0.5317,0.4682,RH,RH
+2018-02-13,Carla Suarez Navarro,Kateryna Bondarenko,0.6039,0.3961,RH,RH
 2018-02-14,Catherine Cartan Bellis,Madison Keys,0.4464,0.5536,RH,RH
-2018-02-14,Sorana Cirstea,Elise Mertens,0.4311,0.5689,RH,LH
-2018-02-15,Garbine Muguruza,Sorana Cirstea,0.7227,0.2773,LH,LH
-2018-02-15,Catherine Cartan Bellis,Karolina Pliskova,0.3367,0.6633,LH,RH
+2018-02-14,Sorana Cirstea,Elise Mertens,0.4311,0.5689,RH,RH
+2018-02-15,Garbine Muguruza,Sorana Cirstea,0.7227,0.2773,RH,RH
+2018-02-15,Catherine Cartan Bellis,Karolina Pliskova,0.3367,0.6633,RH,RH
 2018-02-15,Simona Halep,Anastasija Sevastova,0.6071,0.393,RH,RH
-2018-02-16,Garbine Muguruza,Caroline Garcia,0.4693,0.5308,RH,LH
-2018-02-19,Elena Vesnina,Shuai Peng,0.6281,0.3719,LH,LH
-2018-02-19,Daria Kasatkina,Agnieszka Radwanska,0.3973,0.6027,LH,RH
+2018-02-16,Garbine Muguruza,Caroline Garcia,0.4693,0.5308,RH,RH
+2018-02-19,Elena Vesnina,Shuai Peng,0.6281,0.3719,RH,RH
+2018-02-19,Daria Kasatkina,Agnieszka Radwanska,0.3973,0.6027,RH,RH
 2018-02-20,Catherine Cartan Bellis,Elise Mertens,0.4127,0.5873,RH,RH
-2018-02-20,Anett Kontaveit,Samantha Stosur,0.5087,0.4913,RH,LH
-2018-02-21,Naomi Osaka,Anett Kontaveit,0.4877,0.5123,LH,LH
-2018-02-21,Elena Vesnina,Jelena Ostapenko,0.569,0.431,LH,RH
+2018-02-20,Anett Kontaveit,Samantha Stosur,0.5087,0.4913,RH,RH
+2018-02-21,Naomi Osaka,Anett Kontaveit,0.4877,0.5123,RH,RH
+2018-02-21,Elena Vesnina,Jelena Ostapenko,0.569,0.431,RH,RH
 2018-02-21,Daria Kasatkina,Johanna Konta,0.4558,0.5442,RH,RH
-2018-02-21,Garbine Muguruza,Catherine Cartan Bellis,0.5892,0.4108,RH,LH
-2018-02-22,Elina Svitolina,Naomi Osaka,0.663,0.337,LH,LH
-2018-02-22,Garbine Muguruza,Caroline Garcia,0.4693,0.5308,LH,RH
+2018-02-21,Garbine Muguruza,Catherine Cartan Bellis,0.5892,0.4108,RH,RH
+2018-02-22,Elina Svitolina,Naomi Osaka,0.663,0.337,RH,RH
+2018-02-22,Garbine Muguruza,Caroline Garcia,0.4693,0.5308,RH,RH
 2018-02-22,Daria Kasatkina,Elena Vesnina,0.4974,0.5026,RH,RH
-2018-02-23,Daria Kasatkina,Garbine Muguruza,0.3682,0.6318,RH,LH
-2018-02-24,Elina Svitolina,Daria Kasatkina,0.6758,0.3242,LH,LH
-2018-03-02,Lesia Tsurenko,Kristina Mladenovic,0.3261,0.6739,LH,RH
+2018-02-23,Daria Kasatkina,Garbine Muguruza,0.3682,0.6318,RH,RH
+2018-02-24,Elina Svitolina,Daria Kasatkina,0.6758,0.3242,RH,RH
+2018-03-02,Lesia Tsurenko,Kristina Mladenovic,0.3261,0.6739,RH,RH
 2018-03-07,Qiang Wang,Timea Bacsinszky,0.5398,0.4602,RH,RH
-2018-03-08,Sorana Cirstea,Monica Niculescu,0.4716,0.5284,RH,LH
-2018-03-09,Serena Williams,Zarina Diyas,0.7801,0.2199,LH,LH
-2018-03-09,Qiang Wang,Elise Mertens,0.4147,0.5853,LH,RH
+2018-03-08,Sorana Cirstea,Monica Niculescu,0.4716,0.5284,RH,RH
+2018-03-09,Serena Williams,Zarina Diyas,0.7801,0.2199,RH,RH
+2018-03-09,Qiang Wang,Elise Mertens,0.4147,0.5853,RH,RH
 2018-03-09,Aryna Sabalenka,Svetlana Kuznetsova,0.5509,0.4491,RH,RH
-2018-03-09,Simona Halep,Karolina Pliskova,0.4887,0.5113,RH,LH
-2018-03-10,Daria Kasatkina,Katerina Siniakova,0.642,0.358,LH,LH
-2018-03-10,Elena Vesnina,Catherine Cartan Bellis,0.576,0.424,LH,RH
+2018-03-09,Simona Halep,Karolina Pliskova,0.4887,0.5113,RH,RH
+2018-03-10,Daria Kasatkina,Katerina Siniakova,0.642,0.358,RH,RH
+2018-03-10,Elena Vesnina,Catherine Cartan Bellis,0.576,0.424,RH,RH
 2018-03-12,Anastasija Sevastova,Julia Goerges,0.3144,0.6857,RH,RH
-2018-03-13,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116,RH,LH
-2018-03-13,Venus Williams,Anastasija Sevastova,0.5633,0.4367,LH,LH
-2018-03-14,Daria Kasatkina,Caroline Wozniacki,0.2268,0.7732,LH,RH
+2018-03-13,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116,RH,RH
+2018-03-13,Venus Williams,Anastasija Sevastova,0.5633,0.4367,RH,RH
+2018-03-14,Daria Kasatkina,Caroline Wozniacki,0.2268,0.7732,RH,RH
 2018-03-16,Venus Williams,Carla Suarez Navarro,0.614,0.386,RH,RH
-2018-03-17,Daria Kasatkina,Venus Williams,0.3429,0.6571,RH,LH
-2018-03-17,Naomi Osaka,Simona Halep,0.3734,0.6267,LH,LH
-2018-03-20,Aliaksandra Sasnovich,Karolina Pliskova,0.3046,0.6954,LH,RH
+2018-03-17,Daria Kasatkina,Venus Williams,0.3429,0.6571,RH,RH
+2018-03-17,Naomi Osaka,Simona Halep,0.3734,0.6267,RH,RH
+2018-03-20,Aliaksandra Sasnovich,Karolina Pliskova,0.3046,0.6954,RH,RH
 2018-03-21,Monica Niculescu,Yulia Putintseva,0.3769,0.6231,RH,RH
-2018-03-21,Naomi Osaka,Serena Williams,0.4521,0.5479,RH,LH
-2018-03-22,Monica Puig,Samantha Stosur,0.4563,0.5437,LH,LH
-2018-03-22,Zarina Diyas,Svetlana Kuznetsova,0.4536,0.5464,LH,RH
+2018-03-21,Naomi Osaka,Serena Williams,0.4521,0.5479,RH,RH
+2018-03-22,Monica Puig,Samantha Stosur,0.4563,0.5437,RH,RH
+2018-03-22,Zarina Diyas,Svetlana Kuznetsova,0.4536,0.5464,RH,RH
 2018-03-23,Elina Svitolina,Naomi Osaka,0.5855,0.4145,RH,RH
-2018-03-23,Johanna Konta,Kirsten Flipkens,0.5456,0.4544,RH,LH
-2018-03-24,Monica Puig,Caroline Wozniacki,0.4928,0.5072,LH,LH
-2018-03-24,Agnieszka Radwanska,Simona Halep,0.4767,0.5233,LH,RH
+2018-03-23,Johanna Konta,Kirsten Flipkens,0.5456,0.4544,RH,RH
+2018-03-24,Monica Puig,Caroline Wozniacki,0.4928,0.5072,RH,RH
+2018-03-24,Agnieszka Radwanska,Simona Halep,0.4767,0.5233,RH,RH
 2018-03-26,Elina Svitolina,Ashleigh Barty,0.5766,0.4234,RH,RH
-2018-03-26,Venus Williams,Johanna Konta,0.4744,0.5256,RH,LH
-2018-03-28,Jelena Ostapenko,Elina Svitolina,0.5267,0.4733,LH,LH
-2018-03-31,Sloane Stephens,Jelena Ostapenko,0.4523,0.5477,LH,RH
+2018-03-26,Venus Williams,Johanna Konta,0.4744,0.5256,RH,RH
+2018-03-28,Jelena Ostapenko,Elina Svitolina,0.5267,0.4733,RH,RH
+2018-03-31,Sloane Stephens,Jelena Ostapenko,0.4523,0.5477,RH,RH
 2018-04-03,Karolina Pliskova,Katerina Siniakova,0.6911,0.3089,RH,RH
-2018-04-04,Naomi Osaka,Laura Siegemund,0.472,0.528,RH,LH
-2018-04-04,Kiki Bertens,Aleksandra Krunic,0.4806,0.5194,LH,LH
-2018-04-05,Julia Goerges,Naomi Osaka,0.6678,0.3322,LH,RH
+2018-04-04,Naomi Osaka,Laura Siegemund,0.472,0.528,RH,RH
+2018-04-04,Kiki Bertens,Aleksandra Krunic,0.4806,0.5194,RH,RH
+2018-04-05,Julia Goerges,Naomi Osaka,0.6678,0.3322,RH,RH
 2018-04-05,Anastasija Sevastova,Ashleigh Barty,0.4691,0.5309,RH,RH
-2018-04-05,Karolina Pliskova,Elena Vesnina,0.6367,0.3632,RH,LH
-2018-04-06,Julia Goerges,Daria Kasatkina,0.7912,0.2088,LH,LH
-2018-04-06,Anastasija Sevastova,Karolina Pliskova,0.3379,0.6621,LH,RH
+2018-04-05,Karolina Pliskova,Elena Vesnina,0.6367,0.3632,RH,RH
+2018-04-06,Julia Goerges,Daria Kasatkina,0.7912,0.2088,RH,RH
+2018-04-06,Anastasija Sevastova,Karolina Pliskova,0.3379,0.6621,RH,RH
 2018-04-08,Kiki Bertens,Madison Keys,0.4713,0.5287,RH,RH
-2018-04-08,Julia Goerges,Anastasija Sevastova,0.6593,0.3407,RH,LH
-2018-04-14,Aryna Sabalenka,Stefanie Voegele,0.7358,0.2642,LH,LH
-2018-04-23,Svetlana Kuznetsova,Qiang Wang,0.5748,0.4252,LH,RH
+2018-04-08,Julia Goerges,Anastasija Sevastova,0.6593,0.3407,RH,RH
+2018-04-14,Aryna Sabalenka,Stefanie Voegele,0.7358,0.2642,RH,RH
+2018-04-23,Svetlana Kuznetsova,Qiang Wang,0.5748,0.4252,RH,RH
 2018-04-24,Karolina Pliskova,Kiki Bertens,0.6199,0.3801,RH,RH
-2018-04-25,Coco Vandeweghe,Sloane Stephens,0.5648,0.4352,RH,LH
-2018-04-26,Jelena Ostapenko,Zarina Diyas,0.5853,0.4147,LH,LH
-2018-04-26,Anastasia Pavlyuchenkova,Garbine Muguruza,0.5324,0.4676,LH,RH
+2018-04-25,Coco Vandeweghe,Sloane Stephens,0.5648,0.4352,RH,RH
+2018-04-26,Jelena Ostapenko,Zarina Diyas,0.5853,0.4147,RH,RH
+2018-04-26,Anastasia Pavlyuchenkova,Garbine Muguruza,0.5324,0.4676,RH,RH
 2018-04-27,Coco Vandeweghe,Simona Halep,0.6003,0.3997,RH,RH
-2018-04-27,Caroline Garcia,Elina Svitolina,0.4624,0.5376,RH,LH
-2018-04-27,Anett Kontaveit,Anastasia Pavlyuchenkova,0.4462,0.5537,LH,LH
-2018-04-27,Karolina Pliskova,Jelena Ostapenko,0.5879,0.4121,LH,RH
+2018-04-27,Caroline Garcia,Elina Svitolina,0.4624,0.5376,RH,RH
+2018-04-27,Anett Kontaveit,Anastasia Pavlyuchenkova,0.4462,0.5537,RH,RH
+2018-04-27,Karolina Pliskova,Jelena Ostapenko,0.5879,0.4121,RH,RH
 2018-04-28,Coco Vandeweghe,Caroline Garcia,0.5376,0.4624,RH,RH
-2018-04-28,Karolina Pliskova,Anett Kontaveit,0.6836,0.3164,RH,LH
-2018-04-29,Karolina Pliskova,Coco Vandeweghe,0.5046,0.4955,LH,LH
-2018-05-01,Karolina Pliskova,Aliaksandra Sasnovich,0.7003,0.2997,LH,RH
+2018-04-28,Karolina Pliskova,Anett Kontaveit,0.6836,0.3164,RH,RH
+2018-04-29,Karolina Pliskova,Coco Vandeweghe,0.5046,0.4955,RH,RH
+2018-05-01,Karolina Pliskova,Aliaksandra Sasnovich,0.7003,0.2997,RH,RH
 2018-05-05,Kristina Mladenovic,Coco Vandeweghe,0.5261,0.4739,RH,RH
-2018-05-06,Ashleigh Barty,Sara Errani,0.5822,0.4178,RH,LH
-2018-05-06,Karolina Pliskova,Natalia Vikhlyantseva,0.5788,0.4212,LH,LH
-2018-05-06,Johanna Konta,Magdalena Rybarikova,0.411,0.589,LH,RH
+2018-05-06,Ashleigh Barty,Sara Errani,0.5822,0.4178,RH,RH
+2018-05-06,Karolina Pliskova,Natalia Vikhlyantseva,0.5788,0.4212,RH,RH
+2018-05-06,Johanna Konta,Magdalena Rybarikova,0.411,0.589,RH,RH
 2018-05-07,Caroline Wozniacki,Ashleigh Barty,0.6784,0.3216,RH,RH
-2018-05-07,Kiki Bertens,Anastasija Sevastova,0.5615,0.4385,RH,LH
-2018-05-08,Simona Halep,Elise Mertens,0.4743,0.5257,LH,LH
-2018-05-08,Daria Kasatkina,Sorana Cirstea,0.6377,0.3623,LH,RH
+2018-05-07,Kiki Bertens,Anastasija Sevastova,0.5615,0.4385,RH,RH
+2018-05-08,Simona Halep,Elise Mertens,0.4743,0.5257,RH,RH
+2018-05-08,Daria Kasatkina,Sorana Cirstea,0.6377,0.3623,RH,RH
 2018-05-08,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116,RH,RH
-2018-05-09,Simona Halep,Karolina Pliskova,0.4355,0.5645,RH,LH
-2018-05-09,Kiki Bertens,Caroline Wozniacki,0.3576,0.6424,LH,LH
-2018-05-09,Caroline Garcia,Julia Goerges,0.3752,0.6248,LH,RH
+2018-05-09,Simona Halep,Karolina Pliskova,0.4355,0.5645,RH,RH
+2018-05-09,Kiki Bertens,Caroline Wozniacki,0.3576,0.6424,RH,RH
+2018-05-09,Caroline Garcia,Julia Goerges,0.3752,0.6248,RH,RH
 2018-05-09,Daria Kasatkina,Garbine Muguruza,0.4464,0.5536,RH,RH
-2018-05-10,Caroline Garcia,Carla Suarez Navarro,0.5942,0.4058,RH,LH
-2018-05-10,Karolina Pliskova,Simona Halep,0.5645,0.4355,LH,LH
-2018-05-11,Kiki Bertens,Caroline Garcia,0.4633,0.5366,LH,RH
+2018-05-10,Caroline Garcia,Carla Suarez Navarro,0.5942,0.4058,RH,RH
+2018-05-10,Karolina Pliskova,Simona Halep,0.5645,0.4355,RH,RH
+2018-05-11,Kiki Bertens,Caroline Garcia,0.4633,0.5366,RH,RH
 2018-05-14,Johanna Konta,Magdalena Rybarikova,0.4446,0.5554,RH,RH
-2018-05-14,Petra Martic,Lesia Tsurenko,0.5111,0.4889,RH,LH
-2018-05-15,Irina Camelia Begu,Shuai Peng,0.5039,0.4961,LH,LH
-2018-05-16,Simona Halep,Naomi Osaka,0.5968,0.4032,LH,RH
+2018-05-14,Petra Martic,Lesia Tsurenko,0.5111,0.4889,RH,RH
+2018-05-15,Irina Camelia Begu,Shuai Peng,0.5039,0.4961,RH,RH
+2018-05-16,Simona Halep,Naomi Osaka,0.5968,0.4032,RH,RH
 2018-05-17,Elina Svitolina,Daria Kasatkina,0.6763,0.3237,RH,RH
-2018-05-17,Jelena Ostapenko,Johanna Konta,0.4632,0.5369,RH,LH
-2018-05-17,Simona Halep,Madison Keys,0.6329,0.3671,LH,LH
-2018-05-17,Anett Kontaveit,Venus Williams,0.4385,0.5615,LH,RH
+2018-05-17,Jelena Ostapenko,Johanna Konta,0.4632,0.5369,RH,RH
+2018-05-17,Simona Halep,Madison Keys,0.6329,0.3671,RH,RH
+2018-05-17,Anett Kontaveit,Venus Williams,0.4385,0.5615,RH,RH
 2018-05-17,Caroline Garcia,Sloane Stephens,0.6039,0.3961,RH,RH
-2018-05-17,Caroline Wozniacki,Anastasija Sevastova,0.6563,0.3437,RH,LH
-2018-05-18,Anett Kontaveit,Caroline Wozniacki,0.3653,0.6347,LH,LH
-2018-05-18,Simona Halep,Caroline Garcia,0.4973,0.5027,LH,RH
+2018-05-17,Caroline Wozniacki,Anastasija Sevastova,0.6563,0.3437,RH,RH
+2018-05-18,Anett Kontaveit,Caroline Wozniacki,0.3653,0.6347,RH,RH
+2018-05-18,Simona Halep,Caroline Garcia,0.4973,0.5027,RH,RH
 2018-05-19,Elina Svitolina,Anett Kontaveit,0.5505,0.4496,RH,RH
-2018-05-20,Elina Svitolina,Simona Halep,0.5381,0.4619,RH,LH
-2018-05-23,Yulia Putintseva,Sloane Stephens,0.5598,0.4401,LH,LH
-2018-05-24,Johanna Larsson,Karolina Pliskova,0.3505,0.6495,LH,RH
+2018-05-20,Elina Svitolina,Simona Halep,0.5381,0.4619,RH,RH
+2018-05-23,Yulia Putintseva,Sloane Stephens,0.5598,0.4401,RH,RH
+2018-05-24,Johanna Larsson,Karolina Pliskova,0.3505,0.6495,RH,RH
 2018-05-21,Samantha Stosur,Sofia Kenin,0.5831,0.417,RH,RH
-2018-05-23,Anastasia Pavlyuchenkova,Natalia Vikhlyantseva,0.5276,0.4724,RH,LH
-2018-05-24,Anastasia Pavlyuchenkova,Zarina Diyas,0.5807,0.4193,LH,LH
-2018-05-25,Dominika Cibulkova,Mihaela Buzarnescu,0.5048,0.4952,LH,RH
+2018-05-23,Anastasia Pavlyuchenkova,Natalia Vikhlyantseva,0.5276,0.4724,RH,RH
+2018-05-24,Anastasia Pavlyuchenkova,Zarina Diyas,0.5807,0.4193,RH,RH
+2018-05-25,Dominika Cibulkova,Mihaela Buzarnescu,0.5048,0.4952,RH,RH
 2018-05-25,Anastasia Pavlyuchenkova,Ashleigh Barty,0.5542,0.4458,RH,RH
-2018-05-27,Yulia Putintseva,Johanna Konta,0.3203,0.6797,RH,LH
-2018-05-29,Garbine Muguruza,Svetlana Kuznetsova,0.4849,0.5151,LH,LH
-2018-05-29,Kiki Bertens,Aryna Sabalenka,0.4718,0.5282,LH,RH
+2018-05-27,Yulia Putintseva,Johanna Konta,0.3203,0.6797,RH,RH
+2018-05-29,Garbine Muguruza,Svetlana Kuznetsova,0.4849,0.5151,RH,RH
+2018-05-29,Kiki Bertens,Aryna Sabalenka,0.4718,0.5282,RH,RH
 2018-05-29,Julia Goerges,Dominika Cibulkova,0.6722,0.3278,RH,RH
-2018-05-31,Kiki Bertens,Aliaksandra Sasnovich,0.5299,0.47,RH,LH
-2018-05-31,Serena Williams,Ashleigh Barty,0.4915,0.5085,LH,LH
-2018-06-01,Daria Kasatkina,Maria Sakkari,0.5127,0.4873,LH,RH
+2018-05-31,Kiki Bertens,Aliaksandra Sasnovich,0.5299,0.47,RH,RH
+2018-05-31,Serena Williams,Ashleigh Barty,0.4915,0.5085,RH,RH
+2018-06-01,Daria Kasatkina,Maria Sakkari,0.5127,0.4873,RH,RH
 2018-06-01,Madison Keys,Naomi Osaka,0.504,0.496,RH,RH
-2018-06-02,Caroline Garcia,Irina Camelia Begu,0.5635,0.4365,RH,LH
-2018-06-02,Serena Williams,Julia Goerges,0.4047,0.5954,LH,LH
-2018-06-03,Yulia Putintseva,Barbora Strycova,0.6022,0.3978,LH,RH
+2018-06-02,Caroline Garcia,Irina Camelia Begu,0.5635,0.4365,RH,RH
+2018-06-02,Serena Williams,Julia Goerges,0.4047,0.5954,RH,RH
+2018-06-03,Yulia Putintseva,Barbora Strycova,0.6022,0.3978,RH,RH
 2018-06-03,Sloane Stephens,Anett Kontaveit,0.4703,0.5296,RH,RH
-2018-06-04,Simona Halep,Elise Mertens,0.5274,0.4726,RH,LH
-2018-06-04,Daria Kasatkina,Caroline Wozniacki,0.2704,0.7295,LH,LH
-2018-06-05,Sloane Stephens,Daria Kasatkina,0.5811,0.4189,LH,RH
+2018-06-04,Simona Halep,Elise Mertens,0.5274,0.4726,RH,RH
+2018-06-04,Daria Kasatkina,Caroline Wozniacki,0.2704,0.7295,RH,RH
+2018-06-05,Sloane Stephens,Daria Kasatkina,0.5811,0.4189,RH,RH
 2018-06-06,Simona Halep,Angelique Kerber,0.4587,0.5414,RH,RH
-2018-06-06,Garbine Muguruza,Maria Sharapova,0.4412,0.5588,RH,LH
-2018-06-07,Simona Halep,Garbine Muguruza,0.5346,0.4654,LH,LH
-2018-06-07,Sloane Stephens,Madison Keys,0.4409,0.5591,LH,RH
+2018-06-06,Garbine Muguruza,Maria Sharapova,0.4412,0.5588,RH,RH
+2018-06-07,Simona Halep,Garbine Muguruza,0.5346,0.4654,RH,RH
+2018-06-07,Sloane Stephens,Madison Keys,0.4409,0.5591,RH,RH
 2018-06-11,Coco Vandeweghe,Aliaksandra Sasnovich,0.567,0.4331,RH,RH
-2018-06-12,Alison Riske Amritraj,Tatjana Maria,0.3774,0.6226,RH,LH
-2018-06-15,Coco Vandeweghe,Alison Riske Amritraj,0.7207,0.2793,LH,LH
-2018-06-16,Ashleigh Barty,Naomi Osaka,0.4983,0.5018,LH,RH
+2018-06-12,Alison Riske Amritraj,Tatjana Maria,0.3774,0.6226,RH,RH
+2018-06-15,Coco Vandeweghe,Alison Riske Amritraj,0.7207,0.2793,RH,RH
+2018-06-16,Ashleigh Barty,Naomi Osaka,0.4983,0.5018,RH,RH
 2018-06-17,Ashleigh Barty,Johanna Konta,0.4819,0.5181,RH,RH
-2018-06-18,Magdalena Rybarikova,Karolina Pliskova,0.4158,0.5842,RH,LH
-2018-06-19,Julia Goerges,Maria Sakkari,0.6734,0.3266,LH,LH
-2018-06-19,Daria Kasatkina,Karolina Pliskova,0.2835,0.7165,LH,RH
+2018-06-18,Magdalena Rybarikova,Karolina Pliskova,0.4158,0.5842,RH,RH
+2018-06-19,Julia Goerges,Maria Sakkari,0.6734,0.3266,RH,RH
+2018-06-19,Daria Kasatkina,Karolina Pliskova,0.2835,0.7165,RH,RH
 2018-06-19,Garbine Muguruza,Anastasia Pavlyuchenkova,0.4475,0.5526,RH,RH
-2018-06-21,Julia Goerges,Ashleigh Barty,0.6421,0.3579,RH,LH
-2018-06-18,Tatjana Maria,Anett Kontaveit,0.5394,0.4606,LH,LH
-2018-06-18,Lara Arruabarrena,Carla Suarez Navarro,0.5272,0.4728,LH,RH
+2018-06-21,Julia Goerges,Ashleigh Barty,0.6421,0.3579,RH,RH
+2018-06-18,Tatjana Maria,Anett Kontaveit,0.5394,0.4606,RH,RH
+2018-06-18,Lara Arruabarrena,Carla Suarez Navarro,0.5272,0.4728,RH,RH
 2018-06-19,Anastasija Sevastova,Svetlana Kuznetsova,0.4996,0.5004,RH,RH
-2018-06-20,Caroline Garcia,Johanna Larsson,0.5633,0.4367,RH,LH
-2018-06-24,Anastasia Pavlyuchenkova,Sorana Cirstea,0.7291,0.2708,LH,LH
-2018-06-24,Camila Giorgi,Irina Camelia Begu,0.5776,0.4224,LH,RH
+2018-06-20,Caroline Garcia,Johanna Larsson,0.5633,0.4367,RH,RH
+2018-06-24,Anastasia Pavlyuchenkova,Sorana Cirstea,0.7291,0.2708,RH,RH
+2018-06-24,Camila Giorgi,Irina Camelia Begu,0.5776,0.4224,RH,RH
 2018-06-25,Karolina Pliskova,Anastasia Pavlyuchenkova,0.5452,0.4548,RH,RH
-2018-06-26,Danielle Collins,Carla Suarez Navarro,0.5449,0.4551,RH,LH
-2018-06-26,Aryna Sabalenka,Julia Goerges,0.4761,0.5239,LH,LH
-2018-06-26,Su Wei Hsieh,Magdalena Rybarikova,0.4527,0.5473,LH,RH
+2018-06-26,Danielle Collins,Carla Suarez Navarro,0.5449,0.4551,RH,RH
+2018-06-26,Aryna Sabalenka,Julia Goerges,0.4761,0.5239,RH,RH
+2018-06-26,Su Wei Hsieh,Magdalena Rybarikova,0.4527,0.5473,RH,RH
 2018-06-26,Elise Mertens,Svetlana Kuznetsova,0.5339,0.4661,RH,RH
-2018-06-27,Daria Kasatkina,Anastasija Sevastova,0.4036,0.5963,RH,LH
-2018-06-27,Aryna Sabalenka,Elise Mertens,0.5805,0.4195,LH,LH
-2018-06-27,Caroline Wozniacki,Johanna Konta,0.5516,0.4484,LH,RH
+2018-06-27,Daria Kasatkina,Anastasija Sevastova,0.4036,0.5963,RH,RH
+2018-06-27,Aryna Sabalenka,Elise Mertens,0.5805,0.4195,RH,RH
+2018-06-27,Caroline Wozniacki,Johanna Konta,0.5516,0.4484,RH,RH
 2018-06-28,Agnieszka Radwanska,Jelena Ostapenko,0.5249,0.4751,RH,RH
-2018-06-28,Aryna Sabalenka,Karolina Pliskova,0.4668,0.5332,RH,LH
-2018-06-28,Caroline Wozniacki,Ashleigh Barty,0.6393,0.3607,LH,LH
-2018-06-29,Aryna Sabalenka,Agnieszka Radwanska,0.6006,0.3993,LH,RH
+2018-06-28,Aryna Sabalenka,Karolina Pliskova,0.4668,0.5332,RH,RH
+2018-06-28,Caroline Wozniacki,Ashleigh Barty,0.6393,0.3607,RH,RH
+2018-06-29,Aryna Sabalenka,Agnieszka Radwanska,0.6006,0.3993,RH,RH
 2018-06-30,Caroline Wozniacki,Aryna Sabalenka,0.4934,0.5065,RH,RH
-2018-07-03,Su Wei Hsieh,Anastasia Pavlyuchenkova,0.3753,0.6247,RH,LH
-2018-07-05,Ashleigh Barty,Eugenie Bouchard,0.6669,0.333,LH,LH
-2018-07-05,Su Wei Hsieh,Lara Arruabarrena,0.544,0.4559,LH,RH
+2018-07-03,Su Wei Hsieh,Anastasia Pavlyuchenkova,0.3753,0.6247,RH,RH
+2018-07-05,Ashleigh Barty,Eugenie Bouchard,0.6669,0.333,RH,RH
+2018-07-05,Su Wei Hsieh,Lara Arruabarrena,0.544,0.4559,RH,RH
 2018-07-05,Simona Halep,Saisai Zheng,0.4465,0.5535,RH,RH
-2018-07-05,Dominika Cibulkova,Johanna Konta,0.5348,0.4652,RH,LH
-2018-07-06,Kiki Bertens,Venus Williams,0.5479,0.4521,LH,LH
-2018-07-07,Daria Kasatkina,Ashleigh Barty,0.439,0.5611,LH,RH
+2018-07-05,Dominika Cibulkova,Johanna Konta,0.5348,0.4652,RH,RH
+2018-07-06,Kiki Bertens,Venus Williams,0.5479,0.4521,RH,RH
+2018-07-07,Daria Kasatkina,Ashleigh Barty,0.439,0.5611,RH,RH
 2018-07-07,Dominika Cibulkova,Elise Mertens,0.4334,0.5667,RH,RH
-2018-07-09,Dominika Cibulkova,Su Wei Hsieh,0.5757,0.4243,RH,LH
-2018-07-09,Jelena Ostapenko,Aliaksandra Sasnovich,0.6112,0.3889,LH,LH
-2018-07-09,Kiki Bertens,Karolina Pliskova,0.4088,0.5913,LH,RH
+2018-07-09,Dominika Cibulkova,Su Wei Hsieh,0.5757,0.4243,RH,RH
+2018-07-09,Jelena Ostapenko,Aliaksandra Sasnovich,0.6112,0.3889,RH,RH
+2018-07-09,Kiki Bertens,Karolina Pliskova,0.4088,0.5913,RH,RH
 2018-07-10,Julia Goerges,Kiki Bertens,0.6246,0.3753,RH,RH
-2018-07-10,Serena Williams,Camila Giorgi,0.5592,0.4408,RH,LH
-2018-07-12,Serena Williams,Julia Goerges,0.3876,0.6124,LH,LH
-2018-07-20,Anastasija Sevastova,Sorana Cirstea,0.676,0.324,LH,RH
+2018-07-10,Serena Williams,Camila Giorgi,0.5592,0.4408,RH,RH
+2018-07-12,Serena Williams,Julia Goerges,0.3876,0.6124,RH,RH
+2018-07-20,Anastasija Sevastova,Sorana Cirstea,0.676,0.324,RH,RH
 2018-07-24,Karolina Pliskova,Katerina Siniakova,0.7019,0.2981,RH,RH
-2018-07-27,Aliaksandra Sasnovich,Anastasija Sevastova,0.4568,0.5432,RH,LH
-2018-08-03,Elise Mertens,Johanna Konta,0.5902,0.4098,LH,LH
-2018-08-06,Karolina Pliskova,Katerina Siniakova,0.7043,0.2957,LH,RH
+2018-07-27,Aliaksandra Sasnovich,Anastasija Sevastova,0.4568,0.5432,RH,RH
+2018-08-03,Elise Mertens,Johanna Konta,0.5902,0.4098,RH,RH
+2018-08-06,Karolina Pliskova,Katerina Siniakova,0.7043,0.2957,RH,RH
 2018-08-07,Johanna Konta,Jelena Ostapenko,0.5015,0.4985,RH,RH
-2018-08-07,Elise Mertens,Eugenie Bouchard,0.591,0.409,RH,LH
-2018-08-07,Daria Kasatkina,Maria Sakkari,0.4737,0.5263,LH,LH
-2018-08-08,Carla Suarez Navarro,Lesia Tsurenko,0.5214,0.4786,LH,RH
+2018-08-07,Elise Mertens,Eugenie Bouchard,0.591,0.409,RH,RH
+2018-08-07,Daria Kasatkina,Maria Sakkari,0.4737,0.5263,RH,RH
+2018-08-08,Carla Suarez Navarro,Lesia Tsurenko,0.5214,0.4786,RH,RH
 2018-08-08,Kiki Bertens,Karolina Pliskova,0.4506,0.5494,RH,RH
-2018-08-08,Maria Sharapova,Daria Kasatkina,0.6707,0.3293,RH,LH
-2018-08-08,Elina Svitolina,Mihaela Buzarnescu,0.543,0.4571,LH,LH
-2018-08-08,Elise Mertens,Shuai Zhang,0.5168,0.4832,LH,RH
+2018-08-08,Maria Sharapova,Daria Kasatkina,0.6707,0.3293,RH,RH
+2018-08-08,Elina Svitolina,Mihaela Buzarnescu,0.543,0.4571,RH,RH
+2018-08-08,Elise Mertens,Shuai Zhang,0.5168,0.4832,RH,RH
 2018-08-09,Aryna Sabalenka,Caroline Wozniacki,0.5101,0.4899,RH,RH
-2018-08-09,Sloane Stephens,Carla Suarez Navarro,0.4217,0.5783,RH,LH
-2018-08-09,Anastasija Sevastova,Julia Goerges,0.3558,0.6442,LH,LH
-2018-08-09,Elina Svitolina,Johanna Konta,0.4639,0.536,LH,RH
+2018-08-09,Sloane Stephens,Carla Suarez Navarro,0.4217,0.5783,RH,RH
+2018-08-09,Anastasija Sevastova,Julia Goerges,0.3558,0.6442,RH,RH
+2018-08-09,Elina Svitolina,Johanna Konta,0.4639,0.536,RH,RH
 2018-08-10,Elise Mertens,Aryna Sabalenka,0.4749,0.5251,RH,RH
-2018-08-10,Simona Halep,Venus Williams,0.4685,0.5315,RH,LH
-2018-08-10,Ashleigh Barty,Kiki Bertens,0.4775,0.5225,LH,LH
-2018-08-10,Sloane Stephens,Anastasija Sevastova,0.5005,0.4995,LH,RH
+2018-08-10,Simona Halep,Venus Williams,0.4685,0.5315,RH,RH
+2018-08-10,Ashleigh Barty,Kiki Bertens,0.4775,0.5225,RH,RH
+2018-08-10,Sloane Stephens,Anastasija Sevastova,0.5005,0.4995,RH,RH
 2018-08-10,Simona Halep,Caroline Garcia,0.5845,0.4155,RH,RH
-2018-08-11,Elina Svitolina,Elise Mertens,0.4924,0.5076,RH,LH
-2018-08-11,Simona Halep,Ashleigh Barty,0.4328,0.5672,LH,LH
-2018-08-11,Sloane Stephens,Elina Svitolina,0.5473,0.4527,LH,RH
+2018-08-11,Elina Svitolina,Elise Mertens,0.4924,0.5076,RH,RH
+2018-08-11,Simona Halep,Ashleigh Barty,0.4328,0.5672,RH,RH
+2018-08-11,Sloane Stephens,Elina Svitolina,0.5473,0.4527,RH,RH
 2018-08-13,Aryna Sabalenka,Johanna Konta,0.6064,0.3936,RH,RH
-2018-08-14,Alize Cornet,Jelena Ostapenko,0.2971,0.7029,RH,LH
-2018-08-14,Elise Mertens,Magdalena Rybarikova,0.517,0.4829,LH,LH
-2018-08-14,Karolina Pliskova,Agnieszka Radwanska,0.5539,0.4461,LH,RH
+2018-08-14,Alize Cornet,Jelena Ostapenko,0.2971,0.7029,RH,RH
+2018-08-14,Elise Mertens,Magdalena Rybarikova,0.517,0.4829,RH,RH
+2018-08-14,Karolina Pliskova,Agnieszka Radwanska,0.5539,0.4461,RH,RH
 2018-08-14,Kiki Bertens,Coco Vandeweghe,0.3747,0.6254,RH,RH
-2018-08-14,Petra Martic,Daria Kasatkina,0.6001,0.3999,RH,LH
-2018-08-15,Elina Svitolina,Svetlana Kuznetsova,0.4658,0.5342,LH,LH
-2018-08-15,Aryna Sabalenka,Karolina Pliskova,0.5156,0.4843,LH,RH
+2018-08-14,Petra Martic,Daria Kasatkina,0.6001,0.3999,RH,RH
+2018-08-15,Elina Svitolina,Svetlana Kuznetsova,0.4658,0.5342,RH,RH
+2018-08-15,Aryna Sabalenka,Karolina Pliskova,0.5156,0.4843,RH,RH
 2018-08-15,Sloane Stephens,Tatjana Maria,0.3296,0.6704,RH,RH
-2018-08-15,Lesia Tsurenko,Garbine Muguruza,0.5652,0.4348,RH,LH
-2018-08-16,Kiki Bertens,Caroline Wozniacki,0.5563,0.4437,LH,LH
-2018-08-16,Aryna Sabalenka,Caroline Garcia,0.596,0.4039,LH,RH
+2018-08-15,Lesia Tsurenko,Garbine Muguruza,0.5652,0.4348,RH,RH
+2018-08-16,Kiki Bertens,Caroline Wozniacki,0.5563,0.4437,RH,RH
+2018-08-16,Aryna Sabalenka,Caroline Garcia,0.596,0.4039,RH,RH
 2018-08-16,Elise Mertens,Sloane Stephens,0.5391,0.4609,RH,RH
-2018-08-17,Simona Halep,Ashleigh Barty,0.4328,0.5672,RH,LH
-2018-08-17,Kiki Bertens,Anett Kontaveit,0.4884,0.5116,LH,LH
-2018-08-17,Simona Halep,Lesia Tsurenko,0.5283,0.4717,LH,RH
+2018-08-17,Simona Halep,Ashleigh Barty,0.4328,0.5672,RH,RH
+2018-08-17,Kiki Bertens,Anett Kontaveit,0.4884,0.5116,RH,RH
+2018-08-17,Simona Halep,Lesia Tsurenko,0.5283,0.4717,RH,RH
 2018-08-17,Kiki Bertens,Elina Svitolina,0.5921,0.4078,RH,RH
-2018-08-18,Aryna Sabalenka,Madison Keys,0.6043,0.3957,RH,LH
-2018-08-19,Magdalena Rybarikova,Coco Vandeweghe,0.5112,0.4888,LH,LH
-2018-08-19,Julia Goerges,Dominika Cibulkova,0.7224,0.2776,LH,RH
+2018-08-18,Aryna Sabalenka,Madison Keys,0.6043,0.3957,RH,RH
+2018-08-19,Magdalena Rybarikova,Coco Vandeweghe,0.5112,0.4888,RH,RH
+2018-08-19,Julia Goerges,Dominika Cibulkova,0.7224,0.2776,RH,RH
 2018-08-20,Aliaksandra Sasnovich,Kristina Mladenovic,0.4158,0.5841,RH,RH
-2018-08-24,Aryna Sabalenka,Julia Goerges,0.4618,0.5382,RH,LH
-2018-08-27,Kaia Kanepi,Simona Halep,0.4597,0.5403,LH,LH
-2018-08-27,Garbine Muguruza,Shuai Zhang,0.4632,0.5368,LH,RH
+2018-08-24,Aryna Sabalenka,Julia Goerges,0.4618,0.5382,RH,RH
+2018-08-27,Kaia Kanepi,Simona Halep,0.4597,0.5403,RH,RH
+2018-08-27,Garbine Muguruza,Shuai Zhang,0.4632,0.5368,RH,RH
 2018-08-27,Venus Williams,Svetlana Kuznetsova,0.4659,0.5341,RH,RH
-2018-08-27,Anastasija Sevastova,Donna Vekic,0.5363,0.4637,RH,LH
-2018-08-28,Caroline Wozniacki,Samantha Stosur,0.5272,0.4728,LH,LH
-2018-08-28,Kirsten Flipkens,Coco Vandeweghe,0.5391,0.4609,LH,RH
+2018-08-27,Anastasija Sevastova,Donna Vekic,0.5363,0.4637,RH,RH
+2018-08-28,Caroline Wozniacki,Samantha Stosur,0.5272,0.4728,RH,RH
+2018-08-28,Kirsten Flipkens,Coco Vandeweghe,0.5391,0.4609,RH,RH
 2018-08-28,Kiki Bertens,Karolina Pliskova,0.4808,0.5192,RH,RH
-2018-08-28,Aliaksandra Sasnovich,Belinda Bencic,0.5228,0.4772,RH,LH
-2018-08-28,Caroline Garcia,Johanna Konta,0.5115,0.4885,LH,LH
-2018-08-29,Kristina Mladenovic,Tamara Zidansek,0.6387,0.3613,LH,RH
+2018-08-28,Aliaksandra Sasnovich,Belinda Bencic,0.5228,0.4772,RH,RH
+2018-08-28,Caroline Garcia,Johanna Konta,0.5115,0.4885,RH,RH
+2018-08-29,Kristina Mladenovic,Tamara Zidansek,0.6387,0.3613,RH,RH
 2018-08-29,Elina Svitolina,Tatjana Maria,0.4632,0.5368,RH,RH
-2018-08-29,Qiang Wang,Irina Camelia Begu,0.5518,0.4481,RH,LH
-2018-08-30,Sofia Kenin,Maria Sakkari,0.4353,0.5648,LH,LH
-2018-08-30,Aliaksandra Sasnovich,Daria Kasatkina,0.4857,0.5143,LH,RH
+2018-08-29,Qiang Wang,Irina Camelia Begu,0.5518,0.4481,RH,RH
+2018-08-30,Sofia Kenin,Maria Sakkari,0.4353,0.5648,RH,RH
+2018-08-30,Aliaksandra Sasnovich,Daria Kasatkina,0.4857,0.5143,RH,RH
 2018-08-30,Dominika Cibulkova,Su Wei Hsieh,0.5901,0.4099,RH,RH
-2018-08-31,Lesia Tsurenko,Caroline Wozniacki,0.3916,0.6083,RH,LH
-2018-09-01,Carla Suarez Navarro,Caroline Garcia,0.5116,0.4884,LH,LH
-2018-09-02,Karolina Pliskova,Ashleigh Barty,0.6098,0.3902,LH,RH
+2018-08-31,Lesia Tsurenko,Caroline Wozniacki,0.3916,0.6083,RH,RH
+2018-09-01,Carla Suarez Navarro,Caroline Garcia,0.5116,0.4884,RH,RH
+2018-09-02,Karolina Pliskova,Ashleigh Barty,0.6098,0.3902,RH,RH
 2018-09-02,Anastasija Sevastova,Elina Svitolina,0.4693,0.5307,RH,RH
-2018-09-03,Sloane Stephens,Elise Mertens,0.4375,0.5625,RH,LH
-2018-09-03,Naomi Osaka,Aryna Sabalenka,0.3101,0.6899,LH,LH
-2018-09-04,Carla Suarez Navarro,Maria Sharapova,0.4526,0.5474,LH,RH
+2018-09-03,Sloane Stephens,Elise Mertens,0.4375,0.5625,RH,RH
+2018-09-03,Naomi Osaka,Aryna Sabalenka,0.3101,0.6899,RH,RH
+2018-09-04,Carla Suarez Navarro,Maria Sharapova,0.4526,0.5474,RH,RH
 2018-09-04,Anastasija Sevastova,Sloane Stephens,0.5732,0.4268,RH,RH
-2018-09-05,Naomi Osaka,Lesia Tsurenko,0.4941,0.5059,RH,LH
-2018-09-06,Madison Keys,Carla Suarez Navarro,0.5305,0.4695,LH,LH
-2018-09-07,Serena Williams,Anastasija Sevastova,0.5764,0.4236,LH,RH
+2018-09-05,Naomi Osaka,Lesia Tsurenko,0.4941,0.5059,RH,RH
+2018-09-06,Madison Keys,Carla Suarez Navarro,0.5305,0.4695,RH,RH
+2018-09-07,Serena Williams,Anastasija Sevastova,0.5764,0.4236,RH,RH
 2018-09-07,Naomi Osaka,Madison Keys,0.496,0.504,RH,RH
-2018-09-15,Su Wei Hsieh,Qiang Wang,0.5608,0.4392,RH,LH
-2018-09-10,Christina Mchale,Dayana Yastremska,0.3455,0.6545,LH,LH
-2018-09-19,Ajla Tomljanovic,Tamara Zidansek,0.4104,0.5896,LH,RH
+2018-09-15,Su Wei Hsieh,Qiang Wang,0.5608,0.4392,RH,RH
+2018-09-10,Christina Mchale,Dayana Yastremska,0.3455,0.6545,RH,RH
+2018-09-19,Ajla Tomljanovic,Tamara Zidansek,0.4104,0.5896,RH,RH
 2018-09-21,Maria Sakkari,Irina Camelia Begu,0.5459,0.4541,RH,RH
-2018-09-22,Kiki Bertens,Maria Sakkari,0.5495,0.4505,RH,LH
-2018-09-18,Ashleigh Barty,Coco Vandeweghe,0.4528,0.5472,LH,LH
-2018-09-19,Naomi Osaka,Dominika Cibulkova,0.6033,0.3968,LH,RH
+2018-09-22,Kiki Bertens,Maria Sakkari,0.5495,0.4505,RH,RH
+2018-09-18,Ashleigh Barty,Coco Vandeweghe,0.4528,0.5472,RH,RH
+2018-09-19,Naomi Osaka,Dominika Cibulkova,0.6033,0.3968,RH,RH
 2018-09-20,Donna Vekic,Johanna Konta,0.5112,0.4888,RH,RH
-2018-09-22,Karolina Pliskova,Donna Vekic,0.6511,0.3489,RH,LH
-2018-09-23,Karolina Pliskova,Naomi Osaka,0.6077,0.3923,LH,LH
-2018-09-23,Katerina Siniakova,Kristina Mladenovic,0.3648,0.6352,LH,RH
+2018-09-22,Karolina Pliskova,Donna Vekic,0.6511,0.3489,RH,RH
+2018-09-23,Karolina Pliskova,Naomi Osaka,0.6077,0.3923,RH,RH
+2018-09-23,Katerina Siniakova,Kristina Mladenovic,0.3648,0.6352,RH,RH
 2018-09-23,Anastasia Pavlyuchenkova,Anastasija Sevastova,0.5696,0.4304,RH,RH
-2018-09-23,Daria Kasatkina,Lesia Tsurenko,0.4032,0.5968,RH,LH
-2018-09-23,Aliaksandra Sasnovich,Elise Mertens,0.4365,0.5635,LH,LH
-2018-09-24,Aryna Sabalenka,Carla Suarez Navarro,0.6381,0.3619,LH,RH
+2018-09-23,Daria Kasatkina,Lesia Tsurenko,0.4032,0.5968,RH,RH
+2018-09-23,Aliaksandra Sasnovich,Elise Mertens,0.4365,0.5635,RH,RH
+2018-09-24,Aryna Sabalenka,Carla Suarez Navarro,0.6381,0.3619,RH,RH
 2018-09-24,Ashleigh Barty,Johanna Konta,0.4846,0.5154,RH,RH
-2018-09-25,Aryna Sabalenka,Elina Svitolina,0.5774,0.4226,RH,LH
-2018-09-25,Anastasia Pavlyuchenkova,Kiki Bertens,0.5892,0.4108,LH,LH
-2018-09-26,Dominika Cibulkova,Daria Kasatkina,0.5966,0.4034,LH,RH
+2018-09-25,Aryna Sabalenka,Elina Svitolina,0.5774,0.4226,RH,RH
+2018-09-25,Anastasia Pavlyuchenkova,Kiki Bertens,0.5892,0.4108,RH,RH
+2018-09-26,Dominika Cibulkova,Daria Kasatkina,0.5966,0.4034,RH,RH
 2018-09-26,Katerina Siniakova,Garbine Muguruza,0.3679,0.6321,RH,RH
-2018-09-27,Ashleigh Barty,Anastasia Pavlyuchenkova,0.5126,0.4874,RH,LH
-2018-09-28,Anett Kontaveit,Qiang Wang,0.494,0.506,LH,LH
-2018-09-28,Aryna Sabalenka,Ashleigh Barty,0.5899,0.4101,LH,RH
+2018-09-27,Ashleigh Barty,Anastasia Pavlyuchenkova,0.5126,0.4874,RH,RH
+2018-09-28,Anett Kontaveit,Qiang Wang,0.494,0.506,RH,RH
+2018-09-28,Aryna Sabalenka,Ashleigh Barty,0.5899,0.4101,RH,RH
 2018-09-29,Aryna Sabalenka,Anett Kontaveit,0.6741,0.3259,RH,RH
-2018-09-29,Jelena Ostapenko,Magdalena Rybarikova,0.553,0.447,RH,LH
-2018-09-29,Julia Goerges,Johanna Konta,0.6371,0.3629,LH,LH
-2018-09-30,Ons Jabeur,Simona Halep,0.423,0.577,LH,RH
+2018-09-29,Jelena Ostapenko,Magdalena Rybarikova,0.553,0.447,RH,RH
+2018-09-29,Julia Goerges,Johanna Konta,0.6371,0.3629,RH,RH
+2018-09-30,Ons Jabeur,Simona Halep,0.423,0.577,RH,RH
 2018-09-30,Sloane Stephens,Anastasia Pavlyuchenkova,0.3415,0.6585,RH,RH
-2018-09-30,Kiki Bertens,Sorana Cirstea,0.6623,0.3377,RH,LH
-2018-10-01,Karolina Pliskova,Samantha Stosur,0.5942,0.4058,LH,LH
-2018-10-01,Carla Suarez Navarro,Yulia Putintseva,0.5669,0.4331,LH,RH
+2018-09-30,Kiki Bertens,Sorana Cirstea,0.6623,0.3377,RH,RH
+2018-10-01,Karolina Pliskova,Samantha Stosur,0.5942,0.4058,RH,RH
+2018-10-01,Carla Suarez Navarro,Yulia Putintseva,0.5669,0.4331,RH,RH
 2018-10-01,Shuai Zhang,Elise Mertens,0.5253,0.4747,RH,RH
-2018-10-01,Julia Goerges,Lesia Tsurenko,0.6619,0.3381,RH,LH
-2018-10-01,Anastasija Sevastova,Madison Keys,0.5509,0.4491,LH,LH
-2018-10-02,Aryna Sabalenka,Garbine Muguruza,0.6661,0.3339,LH,RH
+2018-10-01,Julia Goerges,Lesia Tsurenko,0.6619,0.3381,RH,RH
+2018-10-01,Anastasija Sevastova,Madison Keys,0.5509,0.4491,RH,RH
+2018-10-02,Aryna Sabalenka,Garbine Muguruza,0.6661,0.3339,RH,RH
 2018-10-03,Caroline Wozniacki,Petra Martic,0.5486,0.4514,RH,RH
-2018-10-03,Anastasija Sevastova,Donna Vekic,0.5406,0.4594,RH,LH
-2018-10-03,Dominika Cibulkova,Sloane Stephens,0.4901,0.5099,LH,LH
-2018-10-04,Naomi Osaka,Julia Goerges,0.3868,0.6133,LH,RH
+2018-10-03,Anastasija Sevastova,Donna Vekic,0.5406,0.4594,RH,RH
+2018-10-03,Dominika Cibulkova,Sloane Stephens,0.4901,0.5099,RH,RH
+2018-10-04,Naomi Osaka,Julia Goerges,0.3868,0.6133,RH,RH
 2018-10-04,Caroline Wozniacki,Anett Kontaveit,0.6325,0.3674,RH,RH
-2018-10-04,Aryna Sabalenka,Caroline Garcia,0.6316,0.3684,RH,LH
-2018-10-05,Anastasija Sevastova,Dominika Cibulkova,0.6643,0.3357,LH,LH
-2018-10-05,Caroline Wozniacki,Katerina Siniakova,0.5947,0.4053,LH,RH
+2018-10-04,Aryna Sabalenka,Caroline Garcia,0.6316,0.3684,RH,RH
+2018-10-05,Anastasija Sevastova,Dominika Cibulkova,0.6643,0.3357,RH,RH
+2018-10-05,Caroline Wozniacki,Katerina Siniakova,0.5947,0.4053,RH,RH
 2018-10-06,Anastasija Sevastova,Naomi Osaka,0.4646,0.5354,RH,RH
-2018-10-06,Caroline Wozniacki,Qiang Wang,0.6564,0.3436,RH,LH
-2018-10-07,Caroline Wozniacki,Anastasija Sevastova,0.5349,0.4651,LH,LH
-2018-10-13,Qiang Wang,Elina Svitolina,0.3908,0.6092,LH,RH
+2018-10-06,Caroline Wozniacki,Qiang Wang,0.6564,0.3436,RH,RH
+2018-10-07,Caroline Wozniacki,Anastasija Sevastova,0.5349,0.4651,RH,RH
+2018-10-13,Qiang Wang,Elina Svitolina,0.3908,0.6092,RH,RH
 2018-10-13,Qiang Wang,Garbine Muguruza,0.5131,0.4869,RH,RH
-2018-10-12,Su Wei Hsieh,Elise Mertens,0.4229,0.5771,RH,LH
-2018-10-13,Caroline Garcia,Su Wei Hsieh,0.5196,0.4803,LH,LH
-2018-10-14,Caroline Garcia,Karolina Pliskova,0.4154,0.5846,LH,RH
+2018-10-12,Su Wei Hsieh,Elise Mertens,0.4229,0.5771,RH,RH
+2018-10-13,Caroline Garcia,Su Wei Hsieh,0.5196,0.4803,RH,RH
+2018-10-14,Caroline Garcia,Karolina Pliskova,0.4154,0.5846,RH,RH
 2018-10-16,Carla Suarez Navarro,Karolina Pliskova,0.4985,0.5015,RH,RH
-2018-10-18,Julia Goerges,Donna Vekic,0.6541,0.3459,RH,LH
-2018-10-15,Daria Kasatkina,Lesia Tsurenko,0.4139,0.5861,LH,LH
-2018-10-16,Johanna Konta,Elise Mertens,0.5432,0.4568,LH,RH
+2018-10-18,Julia Goerges,Donna Vekic,0.6541,0.3459,RH,RH
+2018-10-15,Daria Kasatkina,Lesia Tsurenko,0.4139,0.5861,RH,RH
+2018-10-16,Johanna Konta,Elise Mertens,0.5432,0.4568,RH,RH
 2018-10-17,Anastasija Sevastova,Yulia Putintseva,0.6666,0.3334,RH,RH
-2018-10-18,Daria Kasatkina,Anastasia Pavlyuchenkova,0.3217,0.6783,RH,LH
-2018-10-19,Daria Kasatkina,Johanna Konta,0.4013,0.5987,LH,LH
-2018-10-21,Karolina Pliskova,Caroline Wozniacki,0.5133,0.4867,LH,RH
+2018-10-18,Daria Kasatkina,Anastasia Pavlyuchenkova,0.3217,0.6783,RH,RH
+2018-10-19,Daria Kasatkina,Johanna Konta,0.4013,0.5987,RH,RH
+2018-10-21,Karolina Pliskova,Caroline Wozniacki,0.5133,0.4867,RH,RH
 2018-10-22,Sloane Stephens,Naomi Osaka,0.4334,0.5666,RH,RH
-2018-10-23,Elina Svitolina,Karolina Pliskova,0.4608,0.5392,RH,LH
-2018-10-24,Sloane Stephens,Kiki Bertens,0.4502,0.5498,LH,LH
-2018-10-25,Elina Svitolina,Caroline Wozniacki,0.4821,0.5179,LH,RH
+2018-10-23,Elina Svitolina,Karolina Pliskova,0.4608,0.5392,RH,RH
+2018-10-24,Sloane Stephens,Kiki Bertens,0.4502,0.5498,RH,RH
+2018-10-25,Elina Svitolina,Caroline Wozniacki,0.4821,0.5179,RH,RH
 2018-10-26,Kiki Bertens,Naomi Osaka,0.5333,0.4667,RH,RH
-2018-10-27,Elina Svitolina,Kiki Bertens,0.5063,0.4937,RH,LH
-2018-10-27,Sloane Stephens,Karolina Pliskova,0.4289,0.5711,LH,LH
-2018-10-28,Elina Svitolina,Sloane Stephens,0.6012,0.3988,LH,RH
+2018-10-27,Elina Svitolina,Kiki Bertens,0.5063,0.4937,RH,RH
+2018-10-27,Sloane Stephens,Karolina Pliskova,0.4289,0.5711,RH,RH
+2018-10-28,Elina Svitolina,Sloane Stephens,0.6012,0.3988,RH,RH
 2018-10-30,Aryna Sabalenka,Ashleigh Barty,0.58,0.42,RH,RH
-2018-10-30,Elise Mertens,Anett Kontaveit,0.4991,0.5009,RH,LH
-2018-10-30,Daria Kasatkina,Qiang Wang,0.3536,0.6464,LH,LH
-2018-10-31,Anett Kontaveit,Julia Goerges,0.3572,0.6428,LH,RH
+2018-10-30,Elise Mertens,Anett Kontaveit,0.4991,0.5009,RH,RH
+2018-10-30,Daria Kasatkina,Qiang Wang,0.3536,0.6464,RH,RH
+2018-10-31,Anett Kontaveit,Julia Goerges,0.3572,0.6428,RH,RH
 2018-10-31,Madison Keys,Daria Kasatkina,0.628,0.372,RH,RH
-2018-10-31,Garbine Muguruza,Shuai Zhang,0.5088,0.4911,RH,LH
-2018-11-01,Ashleigh Barty,Caroline Garcia,0.5215,0.4785,LH,LH
-2018-11-01,Julia Goerges,Elise Mertens,0.6651,0.335,LH,RH
+2018-10-31,Garbine Muguruza,Shuai Zhang,0.5088,0.4911,RH,RH
+2018-11-01,Ashleigh Barty,Caroline Garcia,0.5215,0.4785,RH,RH
+2018-11-01,Julia Goerges,Elise Mertens,0.6651,0.335,RH,RH
 2018-11-02,Caroline Garcia,Aryna Sabalenka,0.3775,0.6225,RH,RH
-2018-11-02,Garbine Muguruza,Anastasija Sevastova,0.3877,0.6123,RH,LH
-2018-11-02,Qiang Wang,Madison Keys,0.4656,0.5344,LH,LH
-2018-11-03,Ashleigh Barty,Julia Goerges,0.3439,0.6561,LH,RH
+2018-11-02,Garbine Muguruza,Anastasija Sevastova,0.3877,0.6123,RH,RH
+2018-11-02,Qiang Wang,Madison Keys,0.4656,0.5344,RH,RH
+2018-11-03,Ashleigh Barty,Julia Goerges,0.3439,0.6561,RH,RH
 2018-11-03,Qiang Wang,Garbine Muguruza,0.5103,0.4897,RH,RH
-2018-11-04,Ashleigh Barty,Qiang Wang,0.5705,0.4295,RH,LH
+2018-11-04,Ashleigh Barty,Qiang Wang,0.5705,0.4295,RH,RH

--- a/MDP_pred.csv
+++ b/MDP_pred.csv
@@ -1,580 +1,580 @@
-date,P1Name,P2Name,P1WinProb,P2WinProb
-2018-01-06,Nick Kyrgios,Grigor Dimitrov,0.6473,0.3527
-2018-01-02,Borna Coric,Pablo Carreno Busta,0.5472,0.4528
-2018-01-06,Gael Monfils,Andrey Rublev,0.5587,0.4412
-2018-01-09,Robin Haase,Casper Ruud,0.5998,0.4002
-2018-01-10,Karen Khachanov,Pablo Cuevas,0.3717,0.6283
-2018-01-12,Juan Martin Del Potro,David Ferrer,0.691,0.309
-2018-01-13,Roberto Bautista Agut,Juan Martin Del Potro,0.4231,0.577
-2018-01-15,Damir Dzumhur,Paolo Lorenzi,0.582,0.418
-2018-01-17,Pablo Carreno Busta,Gilles Simon,0.4495,0.5505
-2018-01-19,Grigor Dimitrov,Andrey Rublev,0.5196,0.4803
-2018-01-20,Tomas Berdych,Juan Martin Del Potro,0.4304,0.5696
-2018-01-21,Marin Cilic,Pablo Carreno Busta,0.6217,0.3783
-2018-01-21,Grigor Dimitrov,Nick Kyrgios,0.363,0.6369
-2018-01-22,Tomas Berdych,Fabio Fognini,0.6863,0.3137
-2018-01-22,Hyeon Chung,Novak Djokovic,0.4047,0.5953
-2018-01-23,Kyle Edmund,Grigor Dimitrov,0.5879,0.4121
-2018-01-24,Roger Federer,Tomas Berdych,0.6765,0.3235
-2018-01-26,Roger Federer,Hyeon Chung,0.7659,0.2342
-2018-02-07,David Goffin,Gilles Simon,0.6005,0.3995
-2018-02-09,Jo Wilfried Tsonga,Andrey Rublev,0.5757,0.4243
-2018-02-10,Richard Gasquet,David Goffin,0.4567,0.5433
-2018-02-10,Lucas Pouille,Jo Wilfried Tsonga,0.4541,0.5459
-2018-02-15,Roger Federer,Philipp Kohlschreiber,0.6558,0.3442
-2018-02-16,Grigor Dimitrov,Andrey Rublev,0.5065,0.4935
-2018-02-17,Grigor Dimitrov,David Goffin,0.4757,0.5243
-2018-02-23,Tomas Berdych,Damir Dzumhur,0.6027,0.3973
-2018-02-23,Lucas Pouille,Filip Krajinovic,0.5421,0.4579
-2018-02-22,Aljaz Bedene,Pablo Carreno Busta,0.5449,0.4551
-2018-02-27,Ryan Harrison,John Isner,0.4485,0.5515
-2018-02-28,Ryan Harrison,Diego Schwartzman,0.7974,0.2026
-2018-03-01,Juan Martin Del Potro,David Ferrer,0.7606,0.2394
-2018-03-02,Juan Martin Del Potro,Dominic Thiem,0.6331,0.3669
-2018-03-04,Juan Martin Del Potro,Kevin Anderson,0.5293,0.4707
-2018-03-02,Roberto Bautista Agut,Malek Jaziri,0.5288,0.4713
-2018-03-12,Juan Martin Del Potro,Alex De Minaur,0.7044,0.2956
-2018-03-12,Roger Federer,Filip Krajinovic,0.6507,0.3493
-2018-03-12,Pablo Carreno Busta,Daniil Medvedev,0.4356,0.5644
-2018-03-12,Borna Coric,Roberto Bautista Agut,0.3184,0.6816
-2018-03-13,Juan Martin Del Potro,David Ferrer,0.7067,0.2933
-2018-03-14,Kevin Anderson,Pablo Carreno Busta,0.6568,0.3431
-2018-03-16,Juan Martin Del Potro,Philipp Kohlschreiber,0.6082,0.3918
-2018-03-17,Juan Martin Del Potro,Milos Raonic,0.4883,0.5118
-2018-03-18,Juan Martin Del Potro,Roger Federer,0.3414,0.6586
-2018-03-24,Alexander Zverev,Daniil Medvedev,0.5194,0.4806
-2018-03-25,Juan Martin Del Potro,Kei Nishikori,0.5986,0.4014
-2018-03-26,Milos Raonic,Diego Schwartzman,0.736,0.264
-2018-03-26,Pablo Carreno Busta,Steve Johnson,0.3966,0.6034
-2018-03-28,Alexander Zverev,Nick Kyrgios,0.4511,0.5489
-2018-03-29,Juan Martin Del Potro,Milos Raonic,0.4919,0.5081
-2018-03-29,Pablo Carreno Busta,Kevin Anderson,0.3431,0.6568
-2018-03-30,Alexander Zverev,Borna Coric,0.6407,0.3593
-2018-03-30,John Isner,Juan Martin Del Potro,0.5998,0.4002
-2018-04-16,Kei Nishikori,Tomas Berdych,0.5077,0.4923
-2018-04-17,Jan Lennard Struff,Yuichi Sugita,0.7556,0.2444
-2018-04-17,Dominic Thiem,Andrey Rublev,0.5087,0.4913
-2018-04-19,David Goffin,Roberto Bautista Agut,0.4778,0.5222
-2018-04-19,Dominic Thiem,Novak Djokovic,0.4637,0.5363
-2018-04-20,Grigor Dimitrov,David Goffin,0.477,0.523
-2018-04-21,Kei Nishikori,Alexander Zverev,0.5249,0.4752
-2018-04-25,Grigor Dimitrov,Gilles Simon,0.6025,0.3975
-2018-04-25,Pablo Carreno Busta,Benoit Paire,0.4602,0.5397
-2018-04-27,Pablo Carreno Busta,Grigor Dimitrov,0.4012,0.5988
-2018-04-27,David Goffin,Roberto Bautista Agut,0.4737,0.5263
-2018-05-01,Mirza Basic,Gael Monfils,0.5244,0.4756
-2018-05-06,Richard Gasquet,Tomas Berdych,0.4528,0.5472
-2018-05-07,Novak Djokovic,Kei Nishikori,0.5914,0.4086
-2018-05-08,Borna Coric,Pablo Carreno Busta,0.4254,0.5746
-2018-05-08,Milos Raonic,Grigor Dimitrov,0.6185,0.3814
-2018-05-08,Juan Martin Del Potro,Damir Dzumhur,0.7369,0.2631
-2018-05-13,Alexander Zverev,Dominic Thiem,0.5265,0.4735
-2018-05-14,Philipp Kohlschreiber,Karen Khachanov,0.505,0.495
-2018-05-15,David Goffin,Marco Cecchinato,0.5288,0.4713
-2018-05-16,Pablo Carreno Busta,Steve Johnson,0.3543,0.6458
-2018-05-17,Pablo Carreno Busta,Aljaz Bedene,0.5528,0.4472
-2018-05-17,David Goffin,Juan Martin Del Potro,0.4073,0.5927
-2018-05-18,Marin Cilic,Pablo Carreno Busta,0.581,0.419
-2018-05-18,Novak Djokovic,Kei Nishikori,0.6028,0.3972
-2018-05-18,Alexander Zverev,David Goffin,0.5222,0.4778
-2018-05-26,Dominic Thiem,Gilles Simon,0.4562,0.5438
-2018-05-30,Kei Nishikori,Benoit Paire,0.5641,0.4358
-2018-06-02,Karen Khachanov,Lucas Pouille,0.509,0.491
-2018-06-04,Diego Schwartzman,Kevin Anderson,0.3537,0.6463
-2018-06-04,Juan Martin Del Potro,John Isner,0.4315,0.5684
-2018-06-05,Marco Cecchinato,Novak Djokovic,0.5017,0.4983
-2018-06-07,Juan Martin Del Potro,Marin Cilic,0.5635,0.4365
-2018-06-10,Rafael Nadal,Dominic Thiem,0.6742,0.3258
-2018-06-13,Milos Raonic,Mirza Basic,0.5555,0.4445
-2018-06-16,Roger Federer,Nick Kyrgios,0.5949,0.4052
-2018-06-17,Roger Federer,Milos Raonic,0.6105,0.3895
-2018-06-21,Roger Federer,Benoit Paire,0.7101,0.2899
-2018-06-22,Roger Federer,Matthew Ebden,0.5256,0.4744
-2018-06-23,Borna Coric,Roberto Bautista Agut,0.4136,0.5864
-2018-06-19,Nick Kyrgios,Andy Murray,0.6029,0.3971
-2018-06-22,Marin Cilic,Sam Querrey,0.5047,0.4954
-2018-06-23,Marin Cilic,Nick Kyrgios,0.4134,0.5865
-2018-06-24,Marin Cilic,Novak Djokovic,0.5411,0.4589
-2018-06-25,Andy Murray,Stan Wawrinka,0.5548,0.4453
-2018-07-03,Juan Martin Del Potro,Peter Gojowczyk,0.6702,0.3298
-2018-07-07,Juan Martin Del Potro,Benoit Paire,0.626,0.374
-2018-07-09,Novak Djokovic,Karen Khachanov,0.4803,0.5197
-2018-07-10,Juan Martin Del Potro,Gilles Simon,0.7488,0.2512
-2018-07-11,Novak Djokovic,Kei Nishikori,0.6041,0.3959
-2018-07-11,Kevin Anderson,Roger Federer,0.3936,0.6063
-2018-07-13,Kevin Anderson,John Isner,0.4368,0.5632
-2018-07-26,John Isner,Alex De Minaur,0.7772,0.2228
-2018-07-29,John Isner,Ryan Harrison,0.6726,0.3274
-2018-07-26,Pablo Carreno Busta,Aljaz Bedene,0.5153,0.4847
-2018-07-27,Nicolas Jarry,Dominic Thiem,0.6273,0.3727
-2018-07-27,Nikoloz Basilashvili,Pablo Carreno Busta,0.4226,0.5774
-2018-08-04,Juan Martin Del Potro,Damir Dzumhur,0.7279,0.2721
-2018-08-05,Fabio Fognini,Juan Martin Del Potro,0.2865,0.7135
-2018-08-02,Alexander Zverev,Malek Jaziri,0.5307,0.4693
-2018-08-04,Alexander Zverev,Kei Nishikori,0.6251,0.3749
-2018-08-05,Alex De Minaur,Andrey Rublev,0.4655,0.5345
-2018-08-07,Stan Wawrinka,Nick Kyrgios,0.3464,0.6535
-2018-08-07,Stefanos Tsitsipas,Damir Dzumhur,0.6317,0.3683
-2018-08-08,Karen Khachanov,Pablo Carreno Busta,0.595,0.405
-2018-08-09,Stefanos Tsitsipas,Novak Djokovic,0.5272,0.4728
-2018-08-09,Marin Cilic,Diego Schwartzman,0.6127,0.3873
-2018-08-13,Pablo Carreno Busta,Richard Gasquet,0.4227,0.5773
-2018-08-14,David Goffin,Stefanos Tsitsipas,0.4516,0.5484
-2018-08-15,Roger Federer,Peter Gojowczyk,0.7367,0.2633
-2018-08-15,Karen Khachanov,Sam Querrey,0.4899,0.5101
-2018-08-16,Stan Wawrinka,Kei Nishikori,0.478,0.522
-2018-08-17,Juan Martin Del Potro,Nick Kyrgios,0.5133,0.4867
-2018-08-17,David Goffin,Kevin Anderson,0.2607,0.7393
-2018-08-17,Novak Djokovic,Grigor Dimitrov,0.6396,0.3604
-2018-08-17,Roger Federer,Leonardo Mayer,0.7126,0.2874
-2018-08-17,Marin Cilic,Pablo Carreno Busta,0.5986,0.4014
-2018-08-18,David Goffin,Juan Martin Del Potro,0.3863,0.6137
-2018-08-18,Roger Federer,Stan Wawrinka,0.7199,0.2801
-2018-08-18,Novak Djokovic,Marin Cilic,0.4922,0.5077
-2018-08-25,Steve Johnson,Pablo Carreno Busta,0.6662,0.3338
-2018-08-27,Stan Wawrinka,Grigor Dimitrov,0.3907,0.6093
-2018-08-27,Kevin Anderson,Ryan Harrison,0.53,0.47
-2018-09-01,Milos Raonic,Stan Wawrinka,0.719,0.281
-2018-09-01,Juan Martin Del Potro,Fernando Verdasco,0.6798,0.3202
-2018-09-01,Roger Federer,Nick Kyrgios,0.5906,0.4094
-2018-09-02,Dominic Thiem,Kevin Anderson,0.3103,0.6898
-2018-09-03,Juan Martin Del Potro,Borna Coric,0.6209,0.3791
-2018-09-03,Marin Cilic,David Goffin,0.4494,0.5506
-2018-09-04,Juan Martin Del Potro,John Isner,0.3992,0.6008
-2018-09-05,Rafael Nadal,Dominic Thiem,0.6843,0.3157
-2018-09-08,Novak Djokovic,Kei Nishikori,0.5989,0.4011
-2018-09-09,Novak Djokovic,Juan Martin Del Potro,0.4526,0.5474
-2018-09-18,Peter Gojowczyk,Jo Wilfried Tsonga,0.3269,0.673
-2018-09-21,Gilles Simon,Richard Gasquet,0.4434,0.5566
-2018-09-21,Kei Nishikori,Nikoloz Basilashvili,0.5711,0.4289
-2018-09-22,Dominic Thiem,Roberto Bautista Agut,0.503,0.497
-2018-09-25,Alex De Minaur,Yuichi Sugita,0.5787,0.4213
-2018-09-27,Andy Murray,David Goffin,0.451,0.549
-2018-09-28,Alex De Minaur,Damir Dzumhur,0.6431,0.3569
-2018-10-01,Karen Khachanov,Sam Querrey,0.5186,0.4814
-2018-10-02,Andrey Rublev,Joao Sousa,0.5403,0.4597
-2018-10-03,Juan Martin Del Potro,Karen Khachanov,0.6089,0.3911
-2018-10-04,Fabio Fognini,Andrey Rublev,0.3754,0.6247
-2018-10-06,Juan Martin Del Potro,Fabio Fognini,0.7196,0.2804
-2018-10-07,Nikoloz Basilashvili,Juan Martin Del Potro,0.3034,0.6966
-2018-10-04,Richard Gasquet,Nick Kyrgios,0.375,0.625
-2018-10-05,Kei Nishikori,Stefanos Tsitsipas,0.3817,0.6183
-2018-10-09,Benoit Paire,Pablo Carreno Busta,0.5289,0.4711
-2018-10-10,Alexander Zverev,Nikoloz Basilashvili,0.625,0.375
-2018-10-10,Alex De Minaur,Benoit Paire,0.4383,0.5617
-2018-10-10,Juan Martin Del Potro,Richard Gasquet,0.6238,0.3762
-2018-10-10,Roger Federer,Daniil Medvedev,0.7087,0.2913
-2018-10-11,Alexander Zverev,Alex De Minaur,0.6754,0.3246
-2018-10-11,Kevin Anderson,Stefanos Tsitsipas,0.681,0.319
-2018-10-11,Borna Coric,Juan Martin Del Potro,0.3569,0.6431
-2018-10-12,Roger Federer,Kei Nishikori,0.7519,0.248
-2018-10-13,Novak Djokovic,Alexander Zverev,0.4424,0.5576
-2018-10-14,Novak Djokovic,Borna Coric,0.5559,0.4441
-2018-10-19,Richard Gasquet,Jan Lennard Struff,0.4461,0.5539
-2018-10-18,Mirza Basic,Nick Kyrgios,0.5074,0.4926
-2018-10-19,Karen Khachanov,Mirza Basic,0.4262,0.5738
-2018-10-26,Roger Federer,Gilles Simon,0.7311,0.2689
-2018-10-26,Daniil Medvedev,Stefanos Tsitsipas,0.4177,0.5822
-2018-10-27,Roger Federer,Daniil Medvedev,0.7193,0.2807
-2018-10-28,Roger Federer,Marius Copil,0.5289,0.4711
-2018-10-23,Sam Querrey,Jo Wilfried Tsonga,0.4753,0.5247
-2018-10-26,Kei Nishikori,Dominic Thiem,0.3365,0.6636
-2018-10-28,Kevin Anderson,Kei Nishikori,0.6627,0.3373
-2018-10-29,Nikoloz Basilashvili,John Millman,0.4628,0.5372
-2018-10-29,Joao Sousa,Marco Cecchinato,0.4701,0.5299
-2018-10-30,Daniil Medvedev,Pablo Carreno Busta,0.5384,0.4616
-2018-10-30,Damir Dzumhur,Stefanos Tsitsipas,0.3288,0.6711
-2018-10-30,Marin Cilic,Philipp Kohlschreiber,0.5724,0.4276
-2018-10-31,Dominic Thiem,Gilles Simon,0.4285,0.5715
-2018-11-01,Alexander Zverev,Diego Schwartzman,0.6349,0.3651
-2018-11-01,Dominic Thiem,Borna Coric,0.5638,0.4362
-2018-11-01,Roger Federer,Fabio Fognini,0.7535,0.2465
-2018-11-01,Kei Nishikori,Kevin Anderson,0.3319,0.6681
-2018-11-02,Dominic Thiem,Jack Sock,0.5859,0.4141
-2018-11-02,Novak Djokovic,Marin Cilic,0.4945,0.5055
-2018-11-02,Roger Federer,Kei Nishikori,0.7428,0.2572
-2018-11-03,Karen Khachanov,Dominic Thiem,0.3892,0.6107
-2018-11-04,Karen Khachanov,Novak Djokovic,0.5004,0.4995
-2018-11-11,Kevin Anderson,Dominic Thiem,0.5535,0.4465
-2018-11-11,Kei Nishikori,Roger Federer,0.2572,0.7428
-2018-11-12,Novak Djokovic,John Isner,0.3271,0.6729
-2018-11-13,Kevin Anderson,Kei Nishikori,0.6711,0.3289
-2018-11-14,Novak Djokovic,Alexander Zverev,0.4997,0.5003
-2018-11-15,Dominic Thiem,Kei Nishikori,0.66,0.34
-2018-11-16,Alexander Zverev,John Isner,0.4456,0.5544
-2018-11-16,Novak Djokovic,Marin Cilic,0.4894,0.5106
-2018-11-17,Alexander Zverev,Roger Federer,0.2777,0.7224
-2018-11-18,Alexander Zverev,Novak Djokovic,0.5003,0.4997
-2018-01-01,Elina Svitolina,Carla Suarez Navarro,0.6811,0.3189
-2018-01-01,Anett Kontaveit,Heather Watson,0.591,0.409
-2018-01-02,Anastasija Sevastova,Sorana Cirstea,0.5033,0.4967
-2018-01-03,Karolina Pliskova,Catherine Cartan Bellis,0.6576,0.3424
-2018-01-04,Aliaksandra Sasnovich,Alize Cornet,0.536,0.464
-2018-01-04,Elina Svitolina,Johanna Konta,0.4912,0.5088
-2018-01-05,Elina Svitolina,Karolina Pliskova,0.4516,0.5484
-2017-12-31,Alison Riske Amritraj,Qiang Wang,0.5113,0.4887
-2017-12-31,Aryna Sabalenka,Monica Niculescu,0.748,0.252
-2018-01-01,Simona Halep,Nicole Gibbs,0.5514,0.4486
-2018-01-02,Karolina Pliskova,Jelena Ostapenko,0.5682,0.4318
-2018-01-02,Zarina Diyas,Shuai Zhang,0.458,0.542
-2018-01-02,Aryna Sabalenka,Danka Kovinic,0.7281,0.272
-2018-01-04,Katerina Siniakova,Karolina Pliskova,0.3606,0.6394
-2018-01-06,Simona Halep,Katerina Siniakova,0.5823,0.4177
-2018-01-08,Lesia Tsurenko,Timea Babos,0.3713,0.6287
-2018-01-08,Aryna Sabalenka,Eugenie Bouchard,0.6198,0.3802
-2018-01-09,Alison Riske Amritraj,Katerina Siniakova,0.4725,0.5275
-2018-01-10,Aryna Sabalenka,Shuai Zhang,0.6947,0.3053
-2018-01-11,Elise Mertens,Monica Niculescu,0.4617,0.5383
-2018-01-08,Dominika Cibulkova,Anastasija Sevastova,0.4831,0.5169
-2018-01-08,Catherine Cartan Bellis,Magdalena Rybarikova,0.4123,0.5877
-2018-01-09,Agnieszka Radwanska,Johanna Konta,0.5341,0.4658
-2018-01-10,Garbine Muguruza,Kiki Bertens,0.5923,0.4077
-2018-01-11,Angelique Kerber,Dominika Cibulkova,0.537,0.463
-2018-01-15,Kiki Bertens,Catherine Cartan Bellis,0.5615,0.4385
-2018-01-15,Monica Puig,Samantha Stosur,0.4445,0.5555
-2018-01-16,Lesia Tsurenko,Natalia Vikhlyantseva,0.3402,0.6598
-2018-01-16,Agnieszka Radwanska,Karolina Pliskova,0.3729,0.6271
-2018-01-17,Elina Svitolina,Katerina Siniakova,0.5851,0.4149
-2018-01-17,Carla Suarez Navarro,Timea Babos,0.5927,0.4073
-2018-01-18,Agnieszka Radwanska,Lesia Tsurenko,0.6624,0.3376
-2018-01-19,Caroline Wozniacki,Kiki Bertens,0.4612,0.5388
-2018-01-22,Madison Keys,Caroline Garcia,0.4586,0.5414
-2018-01-22,Simona Halep,Naomi Osaka,0.6461,0.3539
-2018-01-22,Karolina Pliskova,Barbora Strycova,0.7661,0.2339
-2018-01-24,Simona Halep,Karolina Pliskova,0.4014,0.5985
-2018-01-25,Simona Halep,Angelique Kerber,0.3878,0.6122
-2018-01-27,Caroline Wozniacki,Simona Halep,0.5502,0.4498
-2018-01-30,Dominika Cibulkova,Sorana Cirstea,0.6687,0.3313
-2018-02-01,Kristina Mladenovic,Dominika Cibulkova,0.4662,0.5338
-2018-02-02,Daria Kasatkina,Caroline Wozniacki,0.2369,0.7631
-2018-02-03,Kristina Mladenovic,Daria Kasatkina,0.5682,0.4318
-2018-01-30,Nao Hibino,Samantha Stosur,0.2085,0.7915
-2018-02-12,Catherine Cartan Bellis,Daria Kasatkina,0.4961,0.5039
-2018-02-13,Samantha Stosur,Irina Camelia Begu,0.5317,0.4682
-2018-02-13,Carla Suarez Navarro,Kateryna Bondarenko,0.6039,0.3961
-2018-02-14,Catherine Cartan Bellis,Madison Keys,0.4464,0.5536
-2018-02-14,Sorana Cirstea,Elise Mertens,0.4311,0.5689
-2018-02-15,Garbine Muguruza,Sorana Cirstea,0.7227,0.2773
-2018-02-15,Catherine Cartan Bellis,Karolina Pliskova,0.3367,0.6633
-2018-02-15,Simona Halep,Anastasija Sevastova,0.6071,0.393
-2018-02-16,Garbine Muguruza,Caroline Garcia,0.4693,0.5308
-2018-02-19,Elena Vesnina,Shuai Peng,0.6281,0.3719
-2018-02-19,Daria Kasatkina,Agnieszka Radwanska,0.3973,0.6027
-2018-02-20,Catherine Cartan Bellis,Elise Mertens,0.4127,0.5873
-2018-02-20,Anett Kontaveit,Samantha Stosur,0.5087,0.4913
-2018-02-21,Naomi Osaka,Anett Kontaveit,0.4877,0.5123
-2018-02-21,Elena Vesnina,Jelena Ostapenko,0.569,0.431
-2018-02-21,Daria Kasatkina,Johanna Konta,0.4558,0.5442
-2018-02-21,Garbine Muguruza,Catherine Cartan Bellis,0.5892,0.4108
-2018-02-22,Elina Svitolina,Naomi Osaka,0.663,0.337
-2018-02-22,Garbine Muguruza,Caroline Garcia,0.4693,0.5308
-2018-02-22,Daria Kasatkina,Elena Vesnina,0.4974,0.5026
-2018-02-23,Daria Kasatkina,Garbine Muguruza,0.3682,0.6318
-2018-02-24,Elina Svitolina,Daria Kasatkina,0.6758,0.3242
-2018-03-02,Lesia Tsurenko,Kristina Mladenovic,0.3261,0.6739
-2018-03-07,Qiang Wang,Timea Bacsinszky,0.5398,0.4602
-2018-03-08,Sorana Cirstea,Monica Niculescu,0.4716,0.5284
-2018-03-09,Serena Williams,Zarina Diyas,0.7801,0.2199
-2018-03-09,Qiang Wang,Elise Mertens,0.4147,0.5853
-2018-03-09,Aryna Sabalenka,Svetlana Kuznetsova,0.5509,0.4491
-2018-03-09,Simona Halep,Karolina Pliskova,0.4887,0.5113
-2018-03-10,Daria Kasatkina,Katerina Siniakova,0.642,0.358
-2018-03-10,Elena Vesnina,Catherine Cartan Bellis,0.576,0.424
-2018-03-12,Anastasija Sevastova,Julia Goerges,0.3144,0.6857
-2018-03-13,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116
-2018-03-13,Venus Williams,Anastasija Sevastova,0.5633,0.4367
-2018-03-14,Daria Kasatkina,Caroline Wozniacki,0.2268,0.7732
-2018-03-16,Venus Williams,Carla Suarez Navarro,0.614,0.386
-2018-03-17,Daria Kasatkina,Venus Williams,0.3429,0.6571
-2018-03-17,Naomi Osaka,Simona Halep,0.3734,0.6267
-2018-03-20,Aliaksandra Sasnovich,Karolina Pliskova,0.3046,0.6954
-2018-03-21,Monica Niculescu,Yulia Putintseva,0.3769,0.6231
-2018-03-21,Naomi Osaka,Serena Williams,0.4521,0.5479
-2018-03-22,Monica Puig,Samantha Stosur,0.4563,0.5437
-2018-03-22,Zarina Diyas,Svetlana Kuznetsova,0.4536,0.5464
-2018-03-23,Elina Svitolina,Naomi Osaka,0.5855,0.4145
-2018-03-23,Johanna Konta,Kirsten Flipkens,0.5456,0.4544
-2018-03-24,Monica Puig,Caroline Wozniacki,0.4928,0.5072
-2018-03-24,Agnieszka Radwanska,Simona Halep,0.4767,0.5233
-2018-03-26,Elina Svitolina,Ashleigh Barty,0.5766,0.4234
-2018-03-26,Venus Williams,Johanna Konta,0.4744,0.5256
-2018-03-28,Jelena Ostapenko,Elina Svitolina,0.5267,0.4733
-2018-03-31,Sloane Stephens,Jelena Ostapenko,0.4523,0.5477
-2018-04-03,Karolina Pliskova,Katerina Siniakova,0.6911,0.3089
-2018-04-04,Naomi Osaka,Laura Siegemund,0.472,0.528
-2018-04-04,Kiki Bertens,Aleksandra Krunic,0.4806,0.5194
-2018-04-05,Julia Goerges,Naomi Osaka,0.6678,0.3322
-2018-04-05,Anastasija Sevastova,Ashleigh Barty,0.4691,0.5309
-2018-04-05,Karolina Pliskova,Elena Vesnina,0.6367,0.3632
-2018-04-06,Julia Goerges,Daria Kasatkina,0.7912,0.2088
-2018-04-06,Anastasija Sevastova,Karolina Pliskova,0.3379,0.6621
-2018-04-08,Kiki Bertens,Madison Keys,0.4713,0.5287
-2018-04-08,Julia Goerges,Anastasija Sevastova,0.6593,0.3407
-2018-04-14,Aryna Sabalenka,Stefanie Voegele,0.7358,0.2642
-2018-04-23,Svetlana Kuznetsova,Qiang Wang,0.5748,0.4252
-2018-04-24,Karolina Pliskova,Kiki Bertens,0.6199,0.3801
-2018-04-25,Coco Vandeweghe,Sloane Stephens,0.5648,0.4352
-2018-04-26,Jelena Ostapenko,Zarina Diyas,0.5853,0.4147
-2018-04-26,Anastasia Pavlyuchenkova,Garbine Muguruza,0.5324,0.4676
-2018-04-27,Coco Vandeweghe,Simona Halep,0.6003,0.3997
-2018-04-27,Caroline Garcia,Elina Svitolina,0.4624,0.5376
-2018-04-27,Anett Kontaveit,Anastasia Pavlyuchenkova,0.4462,0.5537
-2018-04-27,Karolina Pliskova,Jelena Ostapenko,0.5879,0.4121
-2018-04-28,Coco Vandeweghe,Caroline Garcia,0.5376,0.4624
-2018-04-28,Karolina Pliskova,Anett Kontaveit,0.6836,0.3164
-2018-04-29,Karolina Pliskova,Coco Vandeweghe,0.5046,0.4955
-2018-05-01,Karolina Pliskova,Aliaksandra Sasnovich,0.7003,0.2997
-2018-05-05,Kristina Mladenovic,Coco Vandeweghe,0.5261,0.4739
-2018-05-06,Ashleigh Barty,Sara Errani,0.5822,0.4178
-2018-05-06,Karolina Pliskova,Natalia Vikhlyantseva,0.5788,0.4212
-2018-05-06,Johanna Konta,Magdalena Rybarikova,0.411,0.589
-2018-05-07,Caroline Wozniacki,Ashleigh Barty,0.6784,0.3216
-2018-05-07,Kiki Bertens,Anastasija Sevastova,0.5615,0.4385
-2018-05-08,Simona Halep,Elise Mertens,0.4743,0.5257
-2018-05-08,Daria Kasatkina,Sorana Cirstea,0.6377,0.3623
-2018-05-08,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116
-2018-05-09,Simona Halep,Karolina Pliskova,0.4355,0.5645
-2018-05-09,Kiki Bertens,Caroline Wozniacki,0.3576,0.6424
-2018-05-09,Caroline Garcia,Julia Goerges,0.3752,0.6248
-2018-05-09,Daria Kasatkina,Garbine Muguruza,0.4464,0.5536
-2018-05-10,Caroline Garcia,Carla Suarez Navarro,0.5942,0.4058
-2018-05-10,Karolina Pliskova,Simona Halep,0.5645,0.4355
-2018-05-11,Kiki Bertens,Caroline Garcia,0.4633,0.5366
-2018-05-14,Johanna Konta,Magdalena Rybarikova,0.4446,0.5554
-2018-05-14,Petra Martic,Lesia Tsurenko,0.5111,0.4889
-2018-05-15,Irina Camelia Begu,Shuai Peng,0.5039,0.4961
-2018-05-16,Simona Halep,Naomi Osaka,0.5968,0.4032
-2018-05-17,Elina Svitolina,Daria Kasatkina,0.6763,0.3237
-2018-05-17,Jelena Ostapenko,Johanna Konta,0.4632,0.5369
-2018-05-17,Simona Halep,Madison Keys,0.6329,0.3671
-2018-05-17,Anett Kontaveit,Venus Williams,0.4385,0.5615
-2018-05-17,Caroline Garcia,Sloane Stephens,0.6039,0.3961
-2018-05-17,Caroline Wozniacki,Anastasija Sevastova,0.6563,0.3437
-2018-05-18,Anett Kontaveit,Caroline Wozniacki,0.3653,0.6347
-2018-05-18,Simona Halep,Caroline Garcia,0.4973,0.5027
-2018-05-19,Elina Svitolina,Anett Kontaveit,0.5505,0.4496
-2018-05-20,Elina Svitolina,Simona Halep,0.5381,0.4619
-2018-05-23,Yulia Putintseva,Sloane Stephens,0.5598,0.4401
-2018-05-24,Johanna Larsson,Karolina Pliskova,0.3505,0.6495
-2018-05-21,Samantha Stosur,Sofia Kenin,0.5831,0.417
-2018-05-23,Anastasia Pavlyuchenkova,Natalia Vikhlyantseva,0.5276,0.4724
-2018-05-24,Anastasia Pavlyuchenkova,Zarina Diyas,0.5807,0.4193
-2018-05-25,Dominika Cibulkova,Mihaela Buzarnescu,0.5048,0.4952
-2018-05-25,Anastasia Pavlyuchenkova,Ashleigh Barty,0.5542,0.4458
-2018-05-27,Yulia Putintseva,Johanna Konta,0.3203,0.6797
-2018-05-29,Garbine Muguruza,Svetlana Kuznetsova,0.4849,0.5151
-2018-05-29,Kiki Bertens,Aryna Sabalenka,0.4718,0.5282
-2018-05-29,Julia Goerges,Dominika Cibulkova,0.6722,0.3278
-2018-05-31,Kiki Bertens,Aliaksandra Sasnovich,0.5299,0.47
-2018-05-31,Serena Williams,Ashleigh Barty,0.4915,0.5085
-2018-06-01,Daria Kasatkina,Maria Sakkari,0.5127,0.4873
-2018-06-01,Madison Keys,Naomi Osaka,0.504,0.496
-2018-06-02,Caroline Garcia,Irina Camelia Begu,0.5635,0.4365
-2018-06-02,Serena Williams,Julia Goerges,0.4047,0.5954
-2018-06-03,Yulia Putintseva,Barbora Strycova,0.6022,0.3978
-2018-06-03,Sloane Stephens,Anett Kontaveit,0.4703,0.5296
-2018-06-04,Simona Halep,Elise Mertens,0.5274,0.4726
-2018-06-04,Daria Kasatkina,Caroline Wozniacki,0.2704,0.7295
-2018-06-05,Sloane Stephens,Daria Kasatkina,0.5811,0.4189
-2018-06-06,Simona Halep,Angelique Kerber,0.4587,0.5414
-2018-06-06,Garbine Muguruza,Maria Sharapova,0.4412,0.5588
-2018-06-07,Simona Halep,Garbine Muguruza,0.5346,0.4654
-2018-06-07,Sloane Stephens,Madison Keys,0.4409,0.5591
-2018-06-11,Coco Vandeweghe,Aliaksandra Sasnovich,0.567,0.4331
-2018-06-12,Alison Riske Amritraj,Tatjana Maria,0.3774,0.6226
-2018-06-15,Coco Vandeweghe,Alison Riske Amritraj,0.7207,0.2793
-2018-06-16,Ashleigh Barty,Naomi Osaka,0.4983,0.5018
-2018-06-17,Ashleigh Barty,Johanna Konta,0.4819,0.5181
-2018-06-18,Magdalena Rybarikova,Karolina Pliskova,0.4158,0.5842
-2018-06-19,Julia Goerges,Maria Sakkari,0.6734,0.3266
-2018-06-19,Daria Kasatkina,Karolina Pliskova,0.2835,0.7165
-2018-06-19,Garbine Muguruza,Anastasia Pavlyuchenkova,0.4475,0.5526
-2018-06-21,Julia Goerges,Ashleigh Barty,0.6421,0.3579
-2018-06-18,Tatjana Maria,Anett Kontaveit,0.5394,0.4606
-2018-06-18,Lara Arruabarrena,Carla Suarez Navarro,0.5272,0.4728
-2018-06-19,Anastasija Sevastova,Svetlana Kuznetsova,0.4996,0.5004
-2018-06-20,Caroline Garcia,Johanna Larsson,0.5633,0.4367
-2018-06-24,Anastasia Pavlyuchenkova,Sorana Cirstea,0.7291,0.2708
-2018-06-24,Camila Giorgi,Irina Camelia Begu,0.5776,0.4224
-2018-06-25,Karolina Pliskova,Anastasia Pavlyuchenkova,0.5452,0.4548
-2018-06-26,Danielle Collins,Carla Suarez Navarro,0.5449,0.4551
-2018-06-26,Aryna Sabalenka,Julia Goerges,0.4761,0.5239
-2018-06-26,Su Wei Hsieh,Magdalena Rybarikova,0.4527,0.5473
-2018-06-26,Elise Mertens,Svetlana Kuznetsova,0.5339,0.4661
-2018-06-27,Daria Kasatkina,Anastasija Sevastova,0.4036,0.5963
-2018-06-27,Aryna Sabalenka,Elise Mertens,0.5805,0.4195
-2018-06-27,Caroline Wozniacki,Johanna Konta,0.5516,0.4484
-2018-06-28,Agnieszka Radwanska,Jelena Ostapenko,0.5249,0.4751
-2018-06-28,Aryna Sabalenka,Karolina Pliskova,0.4668,0.5332
-2018-06-28,Caroline Wozniacki,Ashleigh Barty,0.6393,0.3607
-2018-06-29,Aryna Sabalenka,Agnieszka Radwanska,0.6006,0.3993
-2018-06-30,Caroline Wozniacki,Aryna Sabalenka,0.4934,0.5065
-2018-07-03,Su Wei Hsieh,Anastasia Pavlyuchenkova,0.3753,0.6247
-2018-07-05,Ashleigh Barty,Eugenie Bouchard,0.6669,0.333
-2018-07-05,Su Wei Hsieh,Lara Arruabarrena,0.544,0.4559
-2018-07-05,Simona Halep,Saisai Zheng,0.4465,0.5535
-2018-07-05,Dominika Cibulkova,Johanna Konta,0.5348,0.4652
-2018-07-06,Kiki Bertens,Venus Williams,0.5479,0.4521
-2018-07-07,Daria Kasatkina,Ashleigh Barty,0.439,0.5611
-2018-07-07,Dominika Cibulkova,Elise Mertens,0.4334,0.5667
-2018-07-09,Dominika Cibulkova,Su Wei Hsieh,0.5757,0.4243
-2018-07-09,Jelena Ostapenko,Aliaksandra Sasnovich,0.6112,0.3889
-2018-07-09,Kiki Bertens,Karolina Pliskova,0.4088,0.5913
-2018-07-10,Julia Goerges,Kiki Bertens,0.6246,0.3753
-2018-07-10,Serena Williams,Camila Giorgi,0.5592,0.4408
-2018-07-12,Serena Williams,Julia Goerges,0.3876,0.6124
-2018-07-20,Anastasija Sevastova,Sorana Cirstea,0.676,0.324
-2018-07-24,Karolina Pliskova,Katerina Siniakova,0.7019,0.2981
-2018-07-27,Aliaksandra Sasnovich,Anastasija Sevastova,0.4568,0.5432
-2018-08-03,Elise Mertens,Johanna Konta,0.5902,0.4098
-2018-08-06,Karolina Pliskova,Katerina Siniakova,0.7043,0.2957
-2018-08-07,Johanna Konta,Jelena Ostapenko,0.5015,0.4985
-2018-08-07,Elise Mertens,Eugenie Bouchard,0.591,0.409
-2018-08-07,Daria Kasatkina,Maria Sakkari,0.4737,0.5263
-2018-08-08,Carla Suarez Navarro,Lesia Tsurenko,0.5214,0.4786
-2018-08-08,Kiki Bertens,Karolina Pliskova,0.4506,0.5494
-2018-08-08,Maria Sharapova,Daria Kasatkina,0.6707,0.3293
-2018-08-08,Elina Svitolina,Mihaela Buzarnescu,0.543,0.4571
-2018-08-08,Elise Mertens,Shuai Zhang,0.5168,0.4832
-2018-08-09,Aryna Sabalenka,Caroline Wozniacki,0.5101,0.4899
-2018-08-09,Sloane Stephens,Carla Suarez Navarro,0.4217,0.5783
-2018-08-09,Anastasija Sevastova,Julia Goerges,0.3558,0.6442
-2018-08-09,Elina Svitolina,Johanna Konta,0.4639,0.536
-2018-08-10,Elise Mertens,Aryna Sabalenka,0.4749,0.5251
-2018-08-10,Simona Halep,Venus Williams,0.4685,0.5315
-2018-08-10,Ashleigh Barty,Kiki Bertens,0.4775,0.5225
-2018-08-10,Sloane Stephens,Anastasija Sevastova,0.5005,0.4995
-2018-08-10,Simona Halep,Caroline Garcia,0.5845,0.4155
-2018-08-11,Elina Svitolina,Elise Mertens,0.4924,0.5076
-2018-08-11,Simona Halep,Ashleigh Barty,0.4328,0.5672
-2018-08-11,Sloane Stephens,Elina Svitolina,0.5473,0.4527
-2018-08-13,Aryna Sabalenka,Johanna Konta,0.6064,0.3936
-2018-08-14,Alize Cornet,Jelena Ostapenko,0.2971,0.7029
-2018-08-14,Elise Mertens,Magdalena Rybarikova,0.517,0.4829
-2018-08-14,Karolina Pliskova,Agnieszka Radwanska,0.5539,0.4461
-2018-08-14,Kiki Bertens,Coco Vandeweghe,0.3747,0.6254
-2018-08-14,Petra Martic,Daria Kasatkina,0.6001,0.3999
-2018-08-15,Elina Svitolina,Svetlana Kuznetsova,0.4658,0.5342
-2018-08-15,Aryna Sabalenka,Karolina Pliskova,0.5156,0.4843
-2018-08-15,Sloane Stephens,Tatjana Maria,0.3296,0.6704
-2018-08-15,Lesia Tsurenko,Garbine Muguruza,0.5652,0.4348
-2018-08-16,Kiki Bertens,Caroline Wozniacki,0.5563,0.4437
-2018-08-16,Aryna Sabalenka,Caroline Garcia,0.596,0.4039
-2018-08-16,Elise Mertens,Sloane Stephens,0.5391,0.4609
-2018-08-17,Simona Halep,Ashleigh Barty,0.4328,0.5672
-2018-08-17,Kiki Bertens,Anett Kontaveit,0.4884,0.5116
-2018-08-17,Simona Halep,Lesia Tsurenko,0.5283,0.4717
-2018-08-17,Kiki Bertens,Elina Svitolina,0.5921,0.4078
-2018-08-18,Aryna Sabalenka,Madison Keys,0.6043,0.3957
-2018-08-19,Magdalena Rybarikova,Coco Vandeweghe,0.5112,0.4888
-2018-08-19,Julia Goerges,Dominika Cibulkova,0.7224,0.2776
-2018-08-20,Aliaksandra Sasnovich,Kristina Mladenovic,0.4158,0.5841
-2018-08-24,Aryna Sabalenka,Julia Goerges,0.4618,0.5382
-2018-08-27,Kaia Kanepi,Simona Halep,0.4597,0.5403
-2018-08-27,Garbine Muguruza,Shuai Zhang,0.4632,0.5368
-2018-08-27,Venus Williams,Svetlana Kuznetsova,0.4659,0.5341
-2018-08-27,Anastasija Sevastova,Donna Vekic,0.5363,0.4637
-2018-08-28,Caroline Wozniacki,Samantha Stosur,0.5272,0.4728
-2018-08-28,Kirsten Flipkens,Coco Vandeweghe,0.5391,0.4609
-2018-08-28,Kiki Bertens,Karolina Pliskova,0.4808,0.5192
-2018-08-28,Aliaksandra Sasnovich,Belinda Bencic,0.5228,0.4772
-2018-08-28,Caroline Garcia,Johanna Konta,0.5115,0.4885
-2018-08-29,Kristina Mladenovic,Tamara Zidansek,0.6387,0.3613
-2018-08-29,Elina Svitolina,Tatjana Maria,0.4632,0.5368
-2018-08-29,Qiang Wang,Irina Camelia Begu,0.5518,0.4481
-2018-08-30,Sofia Kenin,Maria Sakkari,0.4353,0.5648
-2018-08-30,Aliaksandra Sasnovich,Daria Kasatkina,0.4857,0.5143
-2018-08-30,Dominika Cibulkova,Su Wei Hsieh,0.5901,0.4099
-2018-08-31,Lesia Tsurenko,Caroline Wozniacki,0.3916,0.6083
-2018-09-01,Carla Suarez Navarro,Caroline Garcia,0.5116,0.4884
-2018-09-02,Karolina Pliskova,Ashleigh Barty,0.6098,0.3902
-2018-09-02,Anastasija Sevastova,Elina Svitolina,0.4693,0.5307
-2018-09-03,Sloane Stephens,Elise Mertens,0.4375,0.5625
-2018-09-03,Naomi Osaka,Aryna Sabalenka,0.3101,0.6899
-2018-09-04,Carla Suarez Navarro,Maria Sharapova,0.4526,0.5474
-2018-09-04,Anastasija Sevastova,Sloane Stephens,0.5732,0.4268
-2018-09-05,Naomi Osaka,Lesia Tsurenko,0.4941,0.5059
-2018-09-06,Madison Keys,Carla Suarez Navarro,0.5305,0.4695
-2018-09-07,Serena Williams,Anastasija Sevastova,0.5764,0.4236
-2018-09-07,Naomi Osaka,Madison Keys,0.496,0.504
-2018-09-15,Su Wei Hsieh,Qiang Wang,0.5608,0.4392
-2018-09-10,Christina Mchale,Dayana Yastremska,0.3455,0.6545
-2018-09-19,Ajla Tomljanovic,Tamara Zidansek,0.4104,0.5896
-2018-09-21,Maria Sakkari,Irina Camelia Begu,0.5459,0.4541
-2018-09-22,Kiki Bertens,Maria Sakkari,0.5495,0.4505
-2018-09-18,Ashleigh Barty,Coco Vandeweghe,0.4528,0.5472
-2018-09-19,Naomi Osaka,Dominika Cibulkova,0.6033,0.3968
-2018-09-20,Donna Vekic,Johanna Konta,0.5112,0.4888
-2018-09-22,Karolina Pliskova,Donna Vekic,0.6511,0.3489
-2018-09-23,Karolina Pliskova,Naomi Osaka,0.6077,0.3923
-2018-09-23,Katerina Siniakova,Kristina Mladenovic,0.3648,0.6352
-2018-09-23,Anastasia Pavlyuchenkova,Anastasija Sevastova,0.5696,0.4304
-2018-09-23,Daria Kasatkina,Lesia Tsurenko,0.4032,0.5968
-2018-09-23,Aliaksandra Sasnovich,Elise Mertens,0.4365,0.5635
-2018-09-24,Aryna Sabalenka,Carla Suarez Navarro,0.6381,0.3619
-2018-09-24,Ashleigh Barty,Johanna Konta,0.4846,0.5154
-2018-09-25,Aryna Sabalenka,Elina Svitolina,0.5774,0.4226
-2018-09-25,Anastasia Pavlyuchenkova,Kiki Bertens,0.5892,0.4108
-2018-09-26,Dominika Cibulkova,Daria Kasatkina,0.5966,0.4034
-2018-09-26,Katerina Siniakova,Garbine Muguruza,0.3679,0.6321
-2018-09-27,Ashleigh Barty,Anastasia Pavlyuchenkova,0.5126,0.4874
-2018-09-28,Anett Kontaveit,Qiang Wang,0.494,0.506
-2018-09-28,Aryna Sabalenka,Ashleigh Barty,0.5899,0.4101
-2018-09-29,Aryna Sabalenka,Anett Kontaveit,0.6741,0.3259
-2018-09-29,Jelena Ostapenko,Magdalena Rybarikova,0.553,0.447
-2018-09-29,Julia Goerges,Johanna Konta,0.6371,0.3629
-2018-09-30,Ons Jabeur,Simona Halep,0.423,0.577
-2018-09-30,Sloane Stephens,Anastasia Pavlyuchenkova,0.3415,0.6585
-2018-09-30,Kiki Bertens,Sorana Cirstea,0.6623,0.3377
-2018-10-01,Karolina Pliskova,Samantha Stosur,0.5942,0.4058
-2018-10-01,Carla Suarez Navarro,Yulia Putintseva,0.5669,0.4331
-2018-10-01,Shuai Zhang,Elise Mertens,0.5253,0.4747
-2018-10-01,Julia Goerges,Lesia Tsurenko,0.6619,0.3381
-2018-10-01,Anastasija Sevastova,Madison Keys,0.5509,0.4491
-2018-10-02,Aryna Sabalenka,Garbine Muguruza,0.6661,0.3339
-2018-10-03,Caroline Wozniacki,Petra Martic,0.5486,0.4514
-2018-10-03,Anastasija Sevastova,Donna Vekic,0.5406,0.4594
-2018-10-03,Dominika Cibulkova,Sloane Stephens,0.4901,0.5099
-2018-10-04,Naomi Osaka,Julia Goerges,0.3868,0.6133
-2018-10-04,Caroline Wozniacki,Anett Kontaveit,0.6325,0.3674
-2018-10-04,Aryna Sabalenka,Caroline Garcia,0.6316,0.3684
-2018-10-05,Anastasija Sevastova,Dominika Cibulkova,0.6643,0.3357
-2018-10-05,Caroline Wozniacki,Katerina Siniakova,0.5947,0.4053
-2018-10-06,Anastasija Sevastova,Naomi Osaka,0.4646,0.5354
-2018-10-06,Caroline Wozniacki,Qiang Wang,0.6564,0.3436
-2018-10-07,Caroline Wozniacki,Anastasija Sevastova,0.5349,0.4651
-2018-10-13,Qiang Wang,Elina Svitolina,0.3908,0.6092
-2018-10-13,Qiang Wang,Garbine Muguruza,0.5131,0.4869
-2018-10-12,Su Wei Hsieh,Elise Mertens,0.4229,0.5771
-2018-10-13,Caroline Garcia,Su Wei Hsieh,0.5196,0.4803
-2018-10-14,Caroline Garcia,Karolina Pliskova,0.4154,0.5846
-2018-10-16,Carla Suarez Navarro,Karolina Pliskova,0.4985,0.5015
-2018-10-18,Julia Goerges,Donna Vekic,0.6541,0.3459
-2018-10-15,Daria Kasatkina,Lesia Tsurenko,0.4139,0.5861
-2018-10-16,Johanna Konta,Elise Mertens,0.5432,0.4568
-2018-10-17,Anastasija Sevastova,Yulia Putintseva,0.6666,0.3334
-2018-10-18,Daria Kasatkina,Anastasia Pavlyuchenkova,0.3217,0.6783
-2018-10-19,Daria Kasatkina,Johanna Konta,0.4013,0.5987
-2018-10-21,Karolina Pliskova,Caroline Wozniacki,0.5133,0.4867
-2018-10-22,Sloane Stephens,Naomi Osaka,0.4334,0.5666
-2018-10-23,Elina Svitolina,Karolina Pliskova,0.4608,0.5392
-2018-10-24,Sloane Stephens,Kiki Bertens,0.4502,0.5498
-2018-10-25,Elina Svitolina,Caroline Wozniacki,0.4821,0.5179
-2018-10-26,Kiki Bertens,Naomi Osaka,0.5333,0.4667
-2018-10-27,Elina Svitolina,Kiki Bertens,0.5063,0.4937
-2018-10-27,Sloane Stephens,Karolina Pliskova,0.4289,0.5711
-2018-10-28,Elina Svitolina,Sloane Stephens,0.6012,0.3988
-2018-10-30,Aryna Sabalenka,Ashleigh Barty,0.58,0.42
-2018-10-30,Elise Mertens,Anett Kontaveit,0.4991,0.5009
-2018-10-30,Daria Kasatkina,Qiang Wang,0.3536,0.6464
-2018-10-31,Anett Kontaveit,Julia Goerges,0.3572,0.6428
-2018-10-31,Madison Keys,Daria Kasatkina,0.628,0.372
-2018-10-31,Garbine Muguruza,Shuai Zhang,0.5088,0.4911
-2018-11-01,Ashleigh Barty,Caroline Garcia,0.5215,0.4785
-2018-11-01,Julia Goerges,Elise Mertens,0.6651,0.335
-2018-11-02,Caroline Garcia,Aryna Sabalenka,0.3775,0.6225
-2018-11-02,Garbine Muguruza,Anastasija Sevastova,0.3877,0.6123
-2018-11-02,Qiang Wang,Madison Keys,0.4656,0.5344
-2018-11-03,Ashleigh Barty,Julia Goerges,0.3439,0.6561
-2018-11-03,Qiang Wang,Garbine Muguruza,0.5103,0.4897
-2018-11-04,Ashleigh Barty,Qiang Wang,0.5705,0.4295
+date,P1Name,P2Name,P1WinProb,P2WinProb,P1Hand,P2Hand
+2018-01-06,Nick Kyrgios,Grigor Dimitrov,0.6473,0.3527,LH,RH
+2018-01-02,Borna Coric,Pablo Carreno Busta,0.5472,0.4528,RH,RH
+2018-01-06,Gael Monfils,Andrey Rublev,0.5587,0.4412,RH,LH
+2018-01-09,Robin Haase,Casper Ruud,0.5998,0.4002,LH,LH
+2018-01-10,Karen Khachanov,Pablo Cuevas,0.3717,0.6283,LH,RH
+2018-01-12,Juan Martin Del Potro,David Ferrer,0.691,0.309,RH,RH
+2018-01-13,Roberto Bautista Agut,Juan Martin Del Potro,0.4231,0.577,RH,LH
+2018-01-15,Damir Dzumhur,Paolo Lorenzi,0.582,0.418,LH,LH
+2018-01-17,Pablo Carreno Busta,Gilles Simon,0.4495,0.5505,LH,RH
+2018-01-19,Grigor Dimitrov,Andrey Rublev,0.5196,0.4803,RH,RH
+2018-01-20,Tomas Berdych,Juan Martin Del Potro,0.4304,0.5696,RH,LH
+2018-01-21,Marin Cilic,Pablo Carreno Busta,0.6217,0.3783,LH,LH
+2018-01-21,Grigor Dimitrov,Nick Kyrgios,0.363,0.6369,LH,RH
+2018-01-22,Tomas Berdych,Fabio Fognini,0.6863,0.3137,RH,RH
+2018-01-22,Hyeon Chung,Novak Djokovic,0.4047,0.5953,RH,LH
+2018-01-23,Kyle Edmund,Grigor Dimitrov,0.5879,0.4121,LH,LH
+2018-01-24,Roger Federer,Tomas Berdych,0.6765,0.3235,LH,RH
+2018-01-26,Roger Federer,Hyeon Chung,0.7659,0.2342,RH,RH
+2018-02-07,David Goffin,Gilles Simon,0.6005,0.3995,RH,LH
+2018-02-09,Jo Wilfried Tsonga,Andrey Rublev,0.5757,0.4243,LH,LH
+2018-02-10,Richard Gasquet,David Goffin,0.4567,0.5433,LH,RH
+2018-02-10,Lucas Pouille,Jo Wilfried Tsonga,0.4541,0.5459,RH,RH
+2018-02-15,Roger Federer,Philipp Kohlschreiber,0.6558,0.3442,RH,LH
+2018-02-16,Grigor Dimitrov,Andrey Rublev,0.5065,0.4935,LH,LH
+2018-02-17,Grigor Dimitrov,David Goffin,0.4757,0.5243,LH,RH
+2018-02-23,Tomas Berdych,Damir Dzumhur,0.6027,0.3973,RH,RH
+2018-02-23,Lucas Pouille,Filip Krajinovic,0.5421,0.4579,RH,LH
+2018-02-22,Aljaz Bedene,Pablo Carreno Busta,0.5449,0.4551,LH,LH
+2018-02-27,Ryan Harrison,John Isner,0.4485,0.5515,LH,RH
+2018-02-28,Ryan Harrison,Diego Schwartzman,0.7974,0.2026,RH,RH
+2018-03-01,Juan Martin Del Potro,David Ferrer,0.7606,0.2394,RH,LH
+2018-03-02,Juan Martin Del Potro,Dominic Thiem,0.6331,0.3669,LH,LH
+2018-03-04,Juan Martin Del Potro,Kevin Anderson,0.5293,0.4707,LH,RH
+2018-03-02,Roberto Bautista Agut,Malek Jaziri,0.5288,0.4713,RH,RH
+2018-03-12,Juan Martin Del Potro,Alex De Minaur,0.7044,0.2956,RH,LH
+2018-03-12,Roger Federer,Filip Krajinovic,0.6507,0.3493,LH,LH
+2018-03-12,Pablo Carreno Busta,Daniil Medvedev,0.4356,0.5644,LH,RH
+2018-03-12,Borna Coric,Roberto Bautista Agut,0.3184,0.6816,RH,RH
+2018-03-13,Juan Martin Del Potro,David Ferrer,0.7067,0.2933,RH,LH
+2018-03-14,Kevin Anderson,Pablo Carreno Busta,0.6568,0.3431,LH,LH
+2018-03-16,Juan Martin Del Potro,Philipp Kohlschreiber,0.6082,0.3918,LH,RH
+2018-03-17,Juan Martin Del Potro,Milos Raonic,0.4883,0.5118,RH,RH
+2018-03-18,Juan Martin Del Potro,Roger Federer,0.3414,0.6586,RH,LH
+2018-03-24,Alexander Zverev,Daniil Medvedev,0.5194,0.4806,LH,LH
+2018-03-25,Juan Martin Del Potro,Kei Nishikori,0.5986,0.4014,LH,RH
+2018-03-26,Milos Raonic,Diego Schwartzman,0.736,0.264,RH,RH
+2018-03-26,Pablo Carreno Busta,Steve Johnson,0.3966,0.6034,RH,LH
+2018-03-28,Alexander Zverev,Nick Kyrgios,0.4511,0.5489,LH,LH
+2018-03-29,Juan Martin Del Potro,Milos Raonic,0.4919,0.5081,LH,RH
+2018-03-29,Pablo Carreno Busta,Kevin Anderson,0.3431,0.6568,RH,RH
+2018-03-30,Alexander Zverev,Borna Coric,0.6407,0.3593,RH,LH
+2018-03-30,John Isner,Juan Martin Del Potro,0.5998,0.4002,LH,LH
+2018-04-16,Kei Nishikori,Tomas Berdych,0.5077,0.4923,LH,RH
+2018-04-17,Jan Lennard Struff,Yuichi Sugita,0.7556,0.2444,RH,RH
+2018-04-17,Dominic Thiem,Andrey Rublev,0.5087,0.4913,RH,LH
+2018-04-19,David Goffin,Roberto Bautista Agut,0.4778,0.5222,LH,LH
+2018-04-19,Dominic Thiem,Novak Djokovic,0.4637,0.5363,LH,RH
+2018-04-20,Grigor Dimitrov,David Goffin,0.477,0.523,RH,RH
+2018-04-21,Kei Nishikori,Alexander Zverev,0.5249,0.4752,RH,LH
+2018-04-25,Grigor Dimitrov,Gilles Simon,0.6025,0.3975,LH,LH
+2018-04-25,Pablo Carreno Busta,Benoit Paire,0.4602,0.5397,LH,RH
+2018-04-27,Pablo Carreno Busta,Grigor Dimitrov,0.4012,0.5988,RH,RH
+2018-04-27,David Goffin,Roberto Bautista Agut,0.4737,0.5263,RH,LH
+2018-05-01,Mirza Basic,Gael Monfils,0.5244,0.4756,LH,LH
+2018-05-06,Richard Gasquet,Tomas Berdych,0.4528,0.5472,LH,RH
+2018-05-07,Novak Djokovic,Kei Nishikori,0.5914,0.4086,RH,RH
+2018-05-08,Borna Coric,Pablo Carreno Busta,0.4254,0.5746,RH,LH
+2018-05-08,Milos Raonic,Grigor Dimitrov,0.6185,0.3814,LH,LH
+2018-05-08,Juan Martin Del Potro,Damir Dzumhur,0.7369,0.2631,LH,RH
+2018-05-13,Alexander Zverev,Dominic Thiem,0.5265,0.4735,RH,RH
+2018-05-14,Philipp Kohlschreiber,Karen Khachanov,0.505,0.495,RH,LH
+2018-05-15,David Goffin,Marco Cecchinato,0.5288,0.4713,LH,LH
+2018-05-16,Pablo Carreno Busta,Steve Johnson,0.3543,0.6458,LH,RH
+2018-05-17,Pablo Carreno Busta,Aljaz Bedene,0.5528,0.4472,RH,RH
+2018-05-17,David Goffin,Juan Martin Del Potro,0.4073,0.5927,RH,LH
+2018-05-18,Marin Cilic,Pablo Carreno Busta,0.581,0.419,LH,LH
+2018-05-18,Novak Djokovic,Kei Nishikori,0.6028,0.3972,LH,RH
+2018-05-18,Alexander Zverev,David Goffin,0.5222,0.4778,RH,RH
+2018-05-26,Dominic Thiem,Gilles Simon,0.4562,0.5438,RH,LH
+2018-05-30,Kei Nishikori,Benoit Paire,0.5641,0.4358,LH,LH
+2018-06-02,Karen Khachanov,Lucas Pouille,0.509,0.491,LH,RH
+2018-06-04,Diego Schwartzman,Kevin Anderson,0.3537,0.6463,RH,RH
+2018-06-04,Juan Martin Del Potro,John Isner,0.4315,0.5684,RH,LH
+2018-06-05,Marco Cecchinato,Novak Djokovic,0.5017,0.4983,LH,LH
+2018-06-07,Juan Martin Del Potro,Marin Cilic,0.5635,0.4365,LH,RH
+2018-06-10,Rafael Nadal,Dominic Thiem,0.6742,0.3258,RH,RH
+2018-06-13,Milos Raonic,Mirza Basic,0.5555,0.4445,RH,LH
+2018-06-16,Roger Federer,Nick Kyrgios,0.5949,0.4052,LH,LH
+2018-06-17,Roger Federer,Milos Raonic,0.6105,0.3895,LH,RH
+2018-06-21,Roger Federer,Benoit Paire,0.7101,0.2899,RH,RH
+2018-06-22,Roger Federer,Matthew Ebden,0.5256,0.4744,RH,LH
+2018-06-23,Borna Coric,Roberto Bautista Agut,0.4136,0.5864,LH,LH
+2018-06-19,Nick Kyrgios,Andy Murray,0.6029,0.3971,LH,RH
+2018-06-22,Marin Cilic,Sam Querrey,0.5047,0.4954,RH,RH
+2018-06-23,Marin Cilic,Nick Kyrgios,0.4134,0.5865,RH,LH
+2018-06-24,Marin Cilic,Novak Djokovic,0.5411,0.4589,LH,LH
+2018-06-25,Andy Murray,Stan Wawrinka,0.5548,0.4453,LH,RH
+2018-07-03,Juan Martin Del Potro,Peter Gojowczyk,0.6702,0.3298,RH,RH
+2018-07-07,Juan Martin Del Potro,Benoit Paire,0.626,0.374,RH,LH
+2018-07-09,Novak Djokovic,Karen Khachanov,0.4803,0.5197,LH,LH
+2018-07-10,Juan Martin Del Potro,Gilles Simon,0.7488,0.2512,LH,RH
+2018-07-11,Novak Djokovic,Kei Nishikori,0.6041,0.3959,RH,RH
+2018-07-11,Kevin Anderson,Roger Federer,0.3936,0.6063,RH,LH
+2018-07-13,Kevin Anderson,John Isner,0.4368,0.5632,LH,LH
+2018-07-26,John Isner,Alex De Minaur,0.7772,0.2228,LH,RH
+2018-07-29,John Isner,Ryan Harrison,0.6726,0.3274,RH,RH
+2018-07-26,Pablo Carreno Busta,Aljaz Bedene,0.5153,0.4847,RH,LH
+2018-07-27,Nicolas Jarry,Dominic Thiem,0.6273,0.3727,LH,LH
+2018-07-27,Nikoloz Basilashvili,Pablo Carreno Busta,0.4226,0.5774,LH,RH
+2018-08-04,Juan Martin Del Potro,Damir Dzumhur,0.7279,0.2721,RH,RH
+2018-08-05,Fabio Fognini,Juan Martin Del Potro,0.2865,0.7135,RH,LH
+2018-08-02,Alexander Zverev,Malek Jaziri,0.5307,0.4693,LH,LH
+2018-08-04,Alexander Zverev,Kei Nishikori,0.6251,0.3749,LH,RH
+2018-08-05,Alex De Minaur,Andrey Rublev,0.4655,0.5345,RH,RH
+2018-08-07,Stan Wawrinka,Nick Kyrgios,0.3464,0.6535,RH,LH
+2018-08-07,Stefanos Tsitsipas,Damir Dzumhur,0.6317,0.3683,LH,LH
+2018-08-08,Karen Khachanov,Pablo Carreno Busta,0.595,0.405,LH,RH
+2018-08-09,Stefanos Tsitsipas,Novak Djokovic,0.5272,0.4728,RH,RH
+2018-08-09,Marin Cilic,Diego Schwartzman,0.6127,0.3873,RH,LH
+2018-08-13,Pablo Carreno Busta,Richard Gasquet,0.4227,0.5773,LH,LH
+2018-08-14,David Goffin,Stefanos Tsitsipas,0.4516,0.5484,LH,RH
+2018-08-15,Roger Federer,Peter Gojowczyk,0.7367,0.2633,RH,RH
+2018-08-15,Karen Khachanov,Sam Querrey,0.4899,0.5101,RH,LH
+2018-08-16,Stan Wawrinka,Kei Nishikori,0.478,0.522,LH,LH
+2018-08-17,Juan Martin Del Potro,Nick Kyrgios,0.5133,0.4867,LH,RH
+2018-08-17,David Goffin,Kevin Anderson,0.2607,0.7393,RH,RH
+2018-08-17,Novak Djokovic,Grigor Dimitrov,0.6396,0.3604,RH,LH
+2018-08-17,Roger Federer,Leonardo Mayer,0.7126,0.2874,LH,LH
+2018-08-17,Marin Cilic,Pablo Carreno Busta,0.5986,0.4014,LH,RH
+2018-08-18,David Goffin,Juan Martin Del Potro,0.3863,0.6137,RH,RH
+2018-08-18,Roger Federer,Stan Wawrinka,0.7199,0.2801,RH,LH
+2018-08-18,Novak Djokovic,Marin Cilic,0.4922,0.5077,LH,LH
+2018-08-25,Steve Johnson,Pablo Carreno Busta,0.6662,0.3338,LH,RH
+2018-08-27,Stan Wawrinka,Grigor Dimitrov,0.3907,0.6093,RH,RH
+2018-08-27,Kevin Anderson,Ryan Harrison,0.53,0.47,RH,LH
+2018-09-01,Milos Raonic,Stan Wawrinka,0.719,0.281,LH,LH
+2018-09-01,Juan Martin Del Potro,Fernando Verdasco,0.6798,0.3202,LH,RH
+2018-09-01,Roger Federer,Nick Kyrgios,0.5906,0.4094,RH,RH
+2018-09-02,Dominic Thiem,Kevin Anderson,0.3103,0.6898,RH,LH
+2018-09-03,Juan Martin Del Potro,Borna Coric,0.6209,0.3791,LH,LH
+2018-09-03,Marin Cilic,David Goffin,0.4494,0.5506,LH,RH
+2018-09-04,Juan Martin Del Potro,John Isner,0.3992,0.6008,RH,RH
+2018-09-05,Rafael Nadal,Dominic Thiem,0.6843,0.3157,RH,LH
+2018-09-08,Novak Djokovic,Kei Nishikori,0.5989,0.4011,LH,LH
+2018-09-09,Novak Djokovic,Juan Martin Del Potro,0.4526,0.5474,LH,RH
+2018-09-18,Peter Gojowczyk,Jo Wilfried Tsonga,0.3269,0.673,RH,RH
+2018-09-21,Gilles Simon,Richard Gasquet,0.4434,0.5566,RH,LH
+2018-09-21,Kei Nishikori,Nikoloz Basilashvili,0.5711,0.4289,LH,LH
+2018-09-22,Dominic Thiem,Roberto Bautista Agut,0.503,0.497,LH,RH
+2018-09-25,Alex De Minaur,Yuichi Sugita,0.5787,0.4213,RH,RH
+2018-09-27,Andy Murray,David Goffin,0.451,0.549,RH,LH
+2018-09-28,Alex De Minaur,Damir Dzumhur,0.6431,0.3569,LH,LH
+2018-10-01,Karen Khachanov,Sam Querrey,0.5186,0.4814,LH,RH
+2018-10-02,Andrey Rublev,Joao Sousa,0.5403,0.4597,RH,RH
+2018-10-03,Juan Martin Del Potro,Karen Khachanov,0.6089,0.3911,RH,LH
+2018-10-04,Fabio Fognini,Andrey Rublev,0.3754,0.6247,LH,LH
+2018-10-06,Juan Martin Del Potro,Fabio Fognini,0.7196,0.2804,LH,RH
+2018-10-07,Nikoloz Basilashvili,Juan Martin Del Potro,0.3034,0.6966,RH,RH
+2018-10-04,Richard Gasquet,Nick Kyrgios,0.375,0.625,RH,LH
+2018-10-05,Kei Nishikori,Stefanos Tsitsipas,0.3817,0.6183,LH,LH
+2018-10-09,Benoit Paire,Pablo Carreno Busta,0.5289,0.4711,LH,RH
+2018-10-10,Alexander Zverev,Nikoloz Basilashvili,0.625,0.375,RH,RH
+2018-10-10,Alex De Minaur,Benoit Paire,0.4383,0.5617,RH,LH
+2018-10-10,Juan Martin Del Potro,Richard Gasquet,0.6238,0.3762,LH,LH
+2018-10-10,Roger Federer,Daniil Medvedev,0.7087,0.2913,LH,RH
+2018-10-11,Alexander Zverev,Alex De Minaur,0.6754,0.3246,RH,RH
+2018-10-11,Kevin Anderson,Stefanos Tsitsipas,0.681,0.319,RH,LH
+2018-10-11,Borna Coric,Juan Martin Del Potro,0.3569,0.6431,LH,LH
+2018-10-12,Roger Federer,Kei Nishikori,0.7519,0.248,LH,RH
+2018-10-13,Novak Djokovic,Alexander Zverev,0.4424,0.5576,RH,RH
+2018-10-14,Novak Djokovic,Borna Coric,0.5559,0.4441,RH,LH
+2018-10-19,Richard Gasquet,Jan Lennard Struff,0.4461,0.5539,LH,LH
+2018-10-18,Mirza Basic,Nick Kyrgios,0.5074,0.4926,LH,RH
+2018-10-19,Karen Khachanov,Mirza Basic,0.4262,0.5738,RH,RH
+2018-10-26,Roger Federer,Gilles Simon,0.7311,0.2689,RH,LH
+2018-10-26,Daniil Medvedev,Stefanos Tsitsipas,0.4177,0.5822,LH,LH
+2018-10-27,Roger Federer,Daniil Medvedev,0.7193,0.2807,LH,RH
+2018-10-28,Roger Federer,Marius Copil,0.5289,0.4711,RH,RH
+2018-10-23,Sam Querrey,Jo Wilfried Tsonga,0.4753,0.5247,RH,LH
+2018-10-26,Kei Nishikori,Dominic Thiem,0.3365,0.6636,LH,LH
+2018-10-28,Kevin Anderson,Kei Nishikori,0.6627,0.3373,LH,RH
+2018-10-29,Nikoloz Basilashvili,John Millman,0.4628,0.5372,RH,RH
+2018-10-29,Joao Sousa,Marco Cecchinato,0.4701,0.5299,RH,LH
+2018-10-30,Daniil Medvedev,Pablo Carreno Busta,0.5384,0.4616,LH,LH
+2018-10-30,Damir Dzumhur,Stefanos Tsitsipas,0.3288,0.6711,LH,RH
+2018-10-30,Marin Cilic,Philipp Kohlschreiber,0.5724,0.4276,RH,RH
+2018-10-31,Dominic Thiem,Gilles Simon,0.4285,0.5715,RH,LH
+2018-11-01,Alexander Zverev,Diego Schwartzman,0.6349,0.3651,LH,LH
+2018-11-01,Dominic Thiem,Borna Coric,0.5638,0.4362,LH,RH
+2018-11-01,Roger Federer,Fabio Fognini,0.7535,0.2465,RH,RH
+2018-11-01,Kei Nishikori,Kevin Anderson,0.3319,0.6681,RH,LH
+2018-11-02,Dominic Thiem,Jack Sock,0.5859,0.4141,LH,LH
+2018-11-02,Novak Djokovic,Marin Cilic,0.4945,0.5055,LH,RH
+2018-11-02,Roger Federer,Kei Nishikori,0.7428,0.2572,RH,RH
+2018-11-03,Karen Khachanov,Dominic Thiem,0.3892,0.6107,RH,LH
+2018-11-04,Karen Khachanov,Novak Djokovic,0.5004,0.4995,LH,LH
+2018-11-11,Kevin Anderson,Dominic Thiem,0.5535,0.4465,LH,RH
+2018-11-11,Kei Nishikori,Roger Federer,0.2572,0.7428,RH,RH
+2018-11-12,Novak Djokovic,John Isner,0.3271,0.6729,RH,LH
+2018-11-13,Kevin Anderson,Kei Nishikori,0.6711,0.3289,LH,LH
+2018-11-14,Novak Djokovic,Alexander Zverev,0.4997,0.5003,LH,RH
+2018-11-15,Dominic Thiem,Kei Nishikori,0.66,0.34,RH,RH
+2018-11-16,Alexander Zverev,John Isner,0.4456,0.5544,RH,LH
+2018-11-16,Novak Djokovic,Marin Cilic,0.4894,0.5106,LH,LH
+2018-11-17,Alexander Zverev,Roger Federer,0.2777,0.7224,LH,RH
+2018-11-18,Alexander Zverev,Novak Djokovic,0.5003,0.4997,RH,RH
+2018-01-01,Elina Svitolina,Carla Suarez Navarro,0.6811,0.3189,RH,LH
+2018-01-01,Anett Kontaveit,Heather Watson,0.591,0.409,LH,LH
+2018-01-02,Anastasija Sevastova,Sorana Cirstea,0.5033,0.4967,LH,RH
+2018-01-03,Karolina Pliskova,Catherine Cartan Bellis,0.6576,0.3424,RH,RH
+2018-01-04,Aliaksandra Sasnovich,Alize Cornet,0.536,0.464,RH,LH
+2018-01-04,Elina Svitolina,Johanna Konta,0.4912,0.5088,LH,LH
+2018-01-05,Elina Svitolina,Karolina Pliskova,0.4516,0.5484,LH,RH
+2017-12-31,Alison Riske Amritraj,Qiang Wang,0.5113,0.4887,RH,RH
+2017-12-31,Aryna Sabalenka,Monica Niculescu,0.748,0.252,RH,LH
+2018-01-01,Simona Halep,Nicole Gibbs,0.5514,0.4486,LH,LH
+2018-01-02,Karolina Pliskova,Jelena Ostapenko,0.5682,0.4318,LH,RH
+2018-01-02,Zarina Diyas,Shuai Zhang,0.458,0.542,RH,RH
+2018-01-02,Aryna Sabalenka,Danka Kovinic,0.7281,0.272,RH,LH
+2018-01-04,Katerina Siniakova,Karolina Pliskova,0.3606,0.6394,LH,LH
+2018-01-06,Simona Halep,Katerina Siniakova,0.5823,0.4177,LH,RH
+2018-01-08,Lesia Tsurenko,Timea Babos,0.3713,0.6287,RH,RH
+2018-01-08,Aryna Sabalenka,Eugenie Bouchard,0.6198,0.3802,RH,LH
+2018-01-09,Alison Riske Amritraj,Katerina Siniakova,0.4725,0.5275,LH,LH
+2018-01-10,Aryna Sabalenka,Shuai Zhang,0.6947,0.3053,LH,RH
+2018-01-11,Elise Mertens,Monica Niculescu,0.4617,0.5383,RH,RH
+2018-01-08,Dominika Cibulkova,Anastasija Sevastova,0.4831,0.5169,RH,LH
+2018-01-08,Catherine Cartan Bellis,Magdalena Rybarikova,0.4123,0.5877,LH,LH
+2018-01-09,Agnieszka Radwanska,Johanna Konta,0.5341,0.4658,LH,RH
+2018-01-10,Garbine Muguruza,Kiki Bertens,0.5923,0.4077,RH,RH
+2018-01-11,Angelique Kerber,Dominika Cibulkova,0.537,0.463,RH,LH
+2018-01-15,Kiki Bertens,Catherine Cartan Bellis,0.5615,0.4385,LH,LH
+2018-01-15,Monica Puig,Samantha Stosur,0.4445,0.5555,LH,RH
+2018-01-16,Lesia Tsurenko,Natalia Vikhlyantseva,0.3402,0.6598,RH,RH
+2018-01-16,Agnieszka Radwanska,Karolina Pliskova,0.3729,0.6271,RH,LH
+2018-01-17,Elina Svitolina,Katerina Siniakova,0.5851,0.4149,LH,LH
+2018-01-17,Carla Suarez Navarro,Timea Babos,0.5927,0.4073,LH,RH
+2018-01-18,Agnieszka Radwanska,Lesia Tsurenko,0.6624,0.3376,RH,RH
+2018-01-19,Caroline Wozniacki,Kiki Bertens,0.4612,0.5388,RH,LH
+2018-01-22,Madison Keys,Caroline Garcia,0.4586,0.5414,LH,LH
+2018-01-22,Simona Halep,Naomi Osaka,0.6461,0.3539,LH,RH
+2018-01-22,Karolina Pliskova,Barbora Strycova,0.7661,0.2339,RH,RH
+2018-01-24,Simona Halep,Karolina Pliskova,0.4014,0.5985,RH,LH
+2018-01-25,Simona Halep,Angelique Kerber,0.3878,0.6122,LH,LH
+2018-01-27,Caroline Wozniacki,Simona Halep,0.5502,0.4498,LH,RH
+2018-01-30,Dominika Cibulkova,Sorana Cirstea,0.6687,0.3313,RH,RH
+2018-02-01,Kristina Mladenovic,Dominika Cibulkova,0.4662,0.5338,RH,LH
+2018-02-02,Daria Kasatkina,Caroline Wozniacki,0.2369,0.7631,LH,LH
+2018-02-03,Kristina Mladenovic,Daria Kasatkina,0.5682,0.4318,LH,RH
+2018-01-30,Nao Hibino,Samantha Stosur,0.2085,0.7915,RH,RH
+2018-02-12,Catherine Cartan Bellis,Daria Kasatkina,0.4961,0.5039,RH,LH
+2018-02-13,Samantha Stosur,Irina Camelia Begu,0.5317,0.4682,LH,LH
+2018-02-13,Carla Suarez Navarro,Kateryna Bondarenko,0.6039,0.3961,LH,RH
+2018-02-14,Catherine Cartan Bellis,Madison Keys,0.4464,0.5536,RH,RH
+2018-02-14,Sorana Cirstea,Elise Mertens,0.4311,0.5689,RH,LH
+2018-02-15,Garbine Muguruza,Sorana Cirstea,0.7227,0.2773,LH,LH
+2018-02-15,Catherine Cartan Bellis,Karolina Pliskova,0.3367,0.6633,LH,RH
+2018-02-15,Simona Halep,Anastasija Sevastova,0.6071,0.393,RH,RH
+2018-02-16,Garbine Muguruza,Caroline Garcia,0.4693,0.5308,RH,LH
+2018-02-19,Elena Vesnina,Shuai Peng,0.6281,0.3719,LH,LH
+2018-02-19,Daria Kasatkina,Agnieszka Radwanska,0.3973,0.6027,LH,RH
+2018-02-20,Catherine Cartan Bellis,Elise Mertens,0.4127,0.5873,RH,RH
+2018-02-20,Anett Kontaveit,Samantha Stosur,0.5087,0.4913,RH,LH
+2018-02-21,Naomi Osaka,Anett Kontaveit,0.4877,0.5123,LH,LH
+2018-02-21,Elena Vesnina,Jelena Ostapenko,0.569,0.431,LH,RH
+2018-02-21,Daria Kasatkina,Johanna Konta,0.4558,0.5442,RH,RH
+2018-02-21,Garbine Muguruza,Catherine Cartan Bellis,0.5892,0.4108,RH,LH
+2018-02-22,Elina Svitolina,Naomi Osaka,0.663,0.337,LH,LH
+2018-02-22,Garbine Muguruza,Caroline Garcia,0.4693,0.5308,LH,RH
+2018-02-22,Daria Kasatkina,Elena Vesnina,0.4974,0.5026,RH,RH
+2018-02-23,Daria Kasatkina,Garbine Muguruza,0.3682,0.6318,RH,LH
+2018-02-24,Elina Svitolina,Daria Kasatkina,0.6758,0.3242,LH,LH
+2018-03-02,Lesia Tsurenko,Kristina Mladenovic,0.3261,0.6739,LH,RH
+2018-03-07,Qiang Wang,Timea Bacsinszky,0.5398,0.4602,RH,RH
+2018-03-08,Sorana Cirstea,Monica Niculescu,0.4716,0.5284,RH,LH
+2018-03-09,Serena Williams,Zarina Diyas,0.7801,0.2199,LH,LH
+2018-03-09,Qiang Wang,Elise Mertens,0.4147,0.5853,LH,RH
+2018-03-09,Aryna Sabalenka,Svetlana Kuznetsova,0.5509,0.4491,RH,RH
+2018-03-09,Simona Halep,Karolina Pliskova,0.4887,0.5113,RH,LH
+2018-03-10,Daria Kasatkina,Katerina Siniakova,0.642,0.358,LH,LH
+2018-03-10,Elena Vesnina,Catherine Cartan Bellis,0.576,0.424,LH,RH
+2018-03-12,Anastasija Sevastova,Julia Goerges,0.3144,0.6857,RH,RH
+2018-03-13,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116,RH,LH
+2018-03-13,Venus Williams,Anastasija Sevastova,0.5633,0.4367,LH,LH
+2018-03-14,Daria Kasatkina,Caroline Wozniacki,0.2268,0.7732,LH,RH
+2018-03-16,Venus Williams,Carla Suarez Navarro,0.614,0.386,RH,RH
+2018-03-17,Daria Kasatkina,Venus Williams,0.3429,0.6571,RH,LH
+2018-03-17,Naomi Osaka,Simona Halep,0.3734,0.6267,LH,LH
+2018-03-20,Aliaksandra Sasnovich,Karolina Pliskova,0.3046,0.6954,LH,RH
+2018-03-21,Monica Niculescu,Yulia Putintseva,0.3769,0.6231,RH,RH
+2018-03-21,Naomi Osaka,Serena Williams,0.4521,0.5479,RH,LH
+2018-03-22,Monica Puig,Samantha Stosur,0.4563,0.5437,LH,LH
+2018-03-22,Zarina Diyas,Svetlana Kuznetsova,0.4536,0.5464,LH,RH
+2018-03-23,Elina Svitolina,Naomi Osaka,0.5855,0.4145,RH,RH
+2018-03-23,Johanna Konta,Kirsten Flipkens,0.5456,0.4544,RH,LH
+2018-03-24,Monica Puig,Caroline Wozniacki,0.4928,0.5072,LH,LH
+2018-03-24,Agnieszka Radwanska,Simona Halep,0.4767,0.5233,LH,RH
+2018-03-26,Elina Svitolina,Ashleigh Barty,0.5766,0.4234,RH,RH
+2018-03-26,Venus Williams,Johanna Konta,0.4744,0.5256,RH,LH
+2018-03-28,Jelena Ostapenko,Elina Svitolina,0.5267,0.4733,LH,LH
+2018-03-31,Sloane Stephens,Jelena Ostapenko,0.4523,0.5477,LH,RH
+2018-04-03,Karolina Pliskova,Katerina Siniakova,0.6911,0.3089,RH,RH
+2018-04-04,Naomi Osaka,Laura Siegemund,0.472,0.528,RH,LH
+2018-04-04,Kiki Bertens,Aleksandra Krunic,0.4806,0.5194,LH,LH
+2018-04-05,Julia Goerges,Naomi Osaka,0.6678,0.3322,LH,RH
+2018-04-05,Anastasija Sevastova,Ashleigh Barty,0.4691,0.5309,RH,RH
+2018-04-05,Karolina Pliskova,Elena Vesnina,0.6367,0.3632,RH,LH
+2018-04-06,Julia Goerges,Daria Kasatkina,0.7912,0.2088,LH,LH
+2018-04-06,Anastasija Sevastova,Karolina Pliskova,0.3379,0.6621,LH,RH
+2018-04-08,Kiki Bertens,Madison Keys,0.4713,0.5287,RH,RH
+2018-04-08,Julia Goerges,Anastasija Sevastova,0.6593,0.3407,RH,LH
+2018-04-14,Aryna Sabalenka,Stefanie Voegele,0.7358,0.2642,LH,LH
+2018-04-23,Svetlana Kuznetsova,Qiang Wang,0.5748,0.4252,LH,RH
+2018-04-24,Karolina Pliskova,Kiki Bertens,0.6199,0.3801,RH,RH
+2018-04-25,Coco Vandeweghe,Sloane Stephens,0.5648,0.4352,RH,LH
+2018-04-26,Jelena Ostapenko,Zarina Diyas,0.5853,0.4147,LH,LH
+2018-04-26,Anastasia Pavlyuchenkova,Garbine Muguruza,0.5324,0.4676,LH,RH
+2018-04-27,Coco Vandeweghe,Simona Halep,0.6003,0.3997,RH,RH
+2018-04-27,Caroline Garcia,Elina Svitolina,0.4624,0.5376,RH,LH
+2018-04-27,Anett Kontaveit,Anastasia Pavlyuchenkova,0.4462,0.5537,LH,LH
+2018-04-27,Karolina Pliskova,Jelena Ostapenko,0.5879,0.4121,LH,RH
+2018-04-28,Coco Vandeweghe,Caroline Garcia,0.5376,0.4624,RH,RH
+2018-04-28,Karolina Pliskova,Anett Kontaveit,0.6836,0.3164,RH,LH
+2018-04-29,Karolina Pliskova,Coco Vandeweghe,0.5046,0.4955,LH,LH
+2018-05-01,Karolina Pliskova,Aliaksandra Sasnovich,0.7003,0.2997,LH,RH
+2018-05-05,Kristina Mladenovic,Coco Vandeweghe,0.5261,0.4739,RH,RH
+2018-05-06,Ashleigh Barty,Sara Errani,0.5822,0.4178,RH,LH
+2018-05-06,Karolina Pliskova,Natalia Vikhlyantseva,0.5788,0.4212,LH,LH
+2018-05-06,Johanna Konta,Magdalena Rybarikova,0.411,0.589,LH,RH
+2018-05-07,Caroline Wozniacki,Ashleigh Barty,0.6784,0.3216,RH,RH
+2018-05-07,Kiki Bertens,Anastasija Sevastova,0.5615,0.4385,RH,LH
+2018-05-08,Simona Halep,Elise Mertens,0.4743,0.5257,LH,LH
+2018-05-08,Daria Kasatkina,Sorana Cirstea,0.6377,0.3623,LH,RH
+2018-05-08,Carla Suarez Navarro,Elina Svitolina,0.3884,0.6116,RH,RH
+2018-05-09,Simona Halep,Karolina Pliskova,0.4355,0.5645,RH,LH
+2018-05-09,Kiki Bertens,Caroline Wozniacki,0.3576,0.6424,LH,LH
+2018-05-09,Caroline Garcia,Julia Goerges,0.3752,0.6248,LH,RH
+2018-05-09,Daria Kasatkina,Garbine Muguruza,0.4464,0.5536,RH,RH
+2018-05-10,Caroline Garcia,Carla Suarez Navarro,0.5942,0.4058,RH,LH
+2018-05-10,Karolina Pliskova,Simona Halep,0.5645,0.4355,LH,LH
+2018-05-11,Kiki Bertens,Caroline Garcia,0.4633,0.5366,LH,RH
+2018-05-14,Johanna Konta,Magdalena Rybarikova,0.4446,0.5554,RH,RH
+2018-05-14,Petra Martic,Lesia Tsurenko,0.5111,0.4889,RH,LH
+2018-05-15,Irina Camelia Begu,Shuai Peng,0.5039,0.4961,LH,LH
+2018-05-16,Simona Halep,Naomi Osaka,0.5968,0.4032,LH,RH
+2018-05-17,Elina Svitolina,Daria Kasatkina,0.6763,0.3237,RH,RH
+2018-05-17,Jelena Ostapenko,Johanna Konta,0.4632,0.5369,RH,LH
+2018-05-17,Simona Halep,Madison Keys,0.6329,0.3671,LH,LH
+2018-05-17,Anett Kontaveit,Venus Williams,0.4385,0.5615,LH,RH
+2018-05-17,Caroline Garcia,Sloane Stephens,0.6039,0.3961,RH,RH
+2018-05-17,Caroline Wozniacki,Anastasija Sevastova,0.6563,0.3437,RH,LH
+2018-05-18,Anett Kontaveit,Caroline Wozniacki,0.3653,0.6347,LH,LH
+2018-05-18,Simona Halep,Caroline Garcia,0.4973,0.5027,LH,RH
+2018-05-19,Elina Svitolina,Anett Kontaveit,0.5505,0.4496,RH,RH
+2018-05-20,Elina Svitolina,Simona Halep,0.5381,0.4619,RH,LH
+2018-05-23,Yulia Putintseva,Sloane Stephens,0.5598,0.4401,LH,LH
+2018-05-24,Johanna Larsson,Karolina Pliskova,0.3505,0.6495,LH,RH
+2018-05-21,Samantha Stosur,Sofia Kenin,0.5831,0.417,RH,RH
+2018-05-23,Anastasia Pavlyuchenkova,Natalia Vikhlyantseva,0.5276,0.4724,RH,LH
+2018-05-24,Anastasia Pavlyuchenkova,Zarina Diyas,0.5807,0.4193,LH,LH
+2018-05-25,Dominika Cibulkova,Mihaela Buzarnescu,0.5048,0.4952,LH,RH
+2018-05-25,Anastasia Pavlyuchenkova,Ashleigh Barty,0.5542,0.4458,RH,RH
+2018-05-27,Yulia Putintseva,Johanna Konta,0.3203,0.6797,RH,LH
+2018-05-29,Garbine Muguruza,Svetlana Kuznetsova,0.4849,0.5151,LH,LH
+2018-05-29,Kiki Bertens,Aryna Sabalenka,0.4718,0.5282,LH,RH
+2018-05-29,Julia Goerges,Dominika Cibulkova,0.6722,0.3278,RH,RH
+2018-05-31,Kiki Bertens,Aliaksandra Sasnovich,0.5299,0.47,RH,LH
+2018-05-31,Serena Williams,Ashleigh Barty,0.4915,0.5085,LH,LH
+2018-06-01,Daria Kasatkina,Maria Sakkari,0.5127,0.4873,LH,RH
+2018-06-01,Madison Keys,Naomi Osaka,0.504,0.496,RH,RH
+2018-06-02,Caroline Garcia,Irina Camelia Begu,0.5635,0.4365,RH,LH
+2018-06-02,Serena Williams,Julia Goerges,0.4047,0.5954,LH,LH
+2018-06-03,Yulia Putintseva,Barbora Strycova,0.6022,0.3978,LH,RH
+2018-06-03,Sloane Stephens,Anett Kontaveit,0.4703,0.5296,RH,RH
+2018-06-04,Simona Halep,Elise Mertens,0.5274,0.4726,RH,LH
+2018-06-04,Daria Kasatkina,Caroline Wozniacki,0.2704,0.7295,LH,LH
+2018-06-05,Sloane Stephens,Daria Kasatkina,0.5811,0.4189,LH,RH
+2018-06-06,Simona Halep,Angelique Kerber,0.4587,0.5414,RH,RH
+2018-06-06,Garbine Muguruza,Maria Sharapova,0.4412,0.5588,RH,LH
+2018-06-07,Simona Halep,Garbine Muguruza,0.5346,0.4654,LH,LH
+2018-06-07,Sloane Stephens,Madison Keys,0.4409,0.5591,LH,RH
+2018-06-11,Coco Vandeweghe,Aliaksandra Sasnovich,0.567,0.4331,RH,RH
+2018-06-12,Alison Riske Amritraj,Tatjana Maria,0.3774,0.6226,RH,LH
+2018-06-15,Coco Vandeweghe,Alison Riske Amritraj,0.7207,0.2793,LH,LH
+2018-06-16,Ashleigh Barty,Naomi Osaka,0.4983,0.5018,LH,RH
+2018-06-17,Ashleigh Barty,Johanna Konta,0.4819,0.5181,RH,RH
+2018-06-18,Magdalena Rybarikova,Karolina Pliskova,0.4158,0.5842,RH,LH
+2018-06-19,Julia Goerges,Maria Sakkari,0.6734,0.3266,LH,LH
+2018-06-19,Daria Kasatkina,Karolina Pliskova,0.2835,0.7165,LH,RH
+2018-06-19,Garbine Muguruza,Anastasia Pavlyuchenkova,0.4475,0.5526,RH,RH
+2018-06-21,Julia Goerges,Ashleigh Barty,0.6421,0.3579,RH,LH
+2018-06-18,Tatjana Maria,Anett Kontaveit,0.5394,0.4606,LH,LH
+2018-06-18,Lara Arruabarrena,Carla Suarez Navarro,0.5272,0.4728,LH,RH
+2018-06-19,Anastasija Sevastova,Svetlana Kuznetsova,0.4996,0.5004,RH,RH
+2018-06-20,Caroline Garcia,Johanna Larsson,0.5633,0.4367,RH,LH
+2018-06-24,Anastasia Pavlyuchenkova,Sorana Cirstea,0.7291,0.2708,LH,LH
+2018-06-24,Camila Giorgi,Irina Camelia Begu,0.5776,0.4224,LH,RH
+2018-06-25,Karolina Pliskova,Anastasia Pavlyuchenkova,0.5452,0.4548,RH,RH
+2018-06-26,Danielle Collins,Carla Suarez Navarro,0.5449,0.4551,RH,LH
+2018-06-26,Aryna Sabalenka,Julia Goerges,0.4761,0.5239,LH,LH
+2018-06-26,Su Wei Hsieh,Magdalena Rybarikova,0.4527,0.5473,LH,RH
+2018-06-26,Elise Mertens,Svetlana Kuznetsova,0.5339,0.4661,RH,RH
+2018-06-27,Daria Kasatkina,Anastasija Sevastova,0.4036,0.5963,RH,LH
+2018-06-27,Aryna Sabalenka,Elise Mertens,0.5805,0.4195,LH,LH
+2018-06-27,Caroline Wozniacki,Johanna Konta,0.5516,0.4484,LH,RH
+2018-06-28,Agnieszka Radwanska,Jelena Ostapenko,0.5249,0.4751,RH,RH
+2018-06-28,Aryna Sabalenka,Karolina Pliskova,0.4668,0.5332,RH,LH
+2018-06-28,Caroline Wozniacki,Ashleigh Barty,0.6393,0.3607,LH,LH
+2018-06-29,Aryna Sabalenka,Agnieszka Radwanska,0.6006,0.3993,LH,RH
+2018-06-30,Caroline Wozniacki,Aryna Sabalenka,0.4934,0.5065,RH,RH
+2018-07-03,Su Wei Hsieh,Anastasia Pavlyuchenkova,0.3753,0.6247,RH,LH
+2018-07-05,Ashleigh Barty,Eugenie Bouchard,0.6669,0.333,LH,LH
+2018-07-05,Su Wei Hsieh,Lara Arruabarrena,0.544,0.4559,LH,RH
+2018-07-05,Simona Halep,Saisai Zheng,0.4465,0.5535,RH,RH
+2018-07-05,Dominika Cibulkova,Johanna Konta,0.5348,0.4652,RH,LH
+2018-07-06,Kiki Bertens,Venus Williams,0.5479,0.4521,LH,LH
+2018-07-07,Daria Kasatkina,Ashleigh Barty,0.439,0.5611,LH,RH
+2018-07-07,Dominika Cibulkova,Elise Mertens,0.4334,0.5667,RH,RH
+2018-07-09,Dominika Cibulkova,Su Wei Hsieh,0.5757,0.4243,RH,LH
+2018-07-09,Jelena Ostapenko,Aliaksandra Sasnovich,0.6112,0.3889,LH,LH
+2018-07-09,Kiki Bertens,Karolina Pliskova,0.4088,0.5913,LH,RH
+2018-07-10,Julia Goerges,Kiki Bertens,0.6246,0.3753,RH,RH
+2018-07-10,Serena Williams,Camila Giorgi,0.5592,0.4408,RH,LH
+2018-07-12,Serena Williams,Julia Goerges,0.3876,0.6124,LH,LH
+2018-07-20,Anastasija Sevastova,Sorana Cirstea,0.676,0.324,LH,RH
+2018-07-24,Karolina Pliskova,Katerina Siniakova,0.7019,0.2981,RH,RH
+2018-07-27,Aliaksandra Sasnovich,Anastasija Sevastova,0.4568,0.5432,RH,LH
+2018-08-03,Elise Mertens,Johanna Konta,0.5902,0.4098,LH,LH
+2018-08-06,Karolina Pliskova,Katerina Siniakova,0.7043,0.2957,LH,RH
+2018-08-07,Johanna Konta,Jelena Ostapenko,0.5015,0.4985,RH,RH
+2018-08-07,Elise Mertens,Eugenie Bouchard,0.591,0.409,RH,LH
+2018-08-07,Daria Kasatkina,Maria Sakkari,0.4737,0.5263,LH,LH
+2018-08-08,Carla Suarez Navarro,Lesia Tsurenko,0.5214,0.4786,LH,RH
+2018-08-08,Kiki Bertens,Karolina Pliskova,0.4506,0.5494,RH,RH
+2018-08-08,Maria Sharapova,Daria Kasatkina,0.6707,0.3293,RH,LH
+2018-08-08,Elina Svitolina,Mihaela Buzarnescu,0.543,0.4571,LH,LH
+2018-08-08,Elise Mertens,Shuai Zhang,0.5168,0.4832,LH,RH
+2018-08-09,Aryna Sabalenka,Caroline Wozniacki,0.5101,0.4899,RH,RH
+2018-08-09,Sloane Stephens,Carla Suarez Navarro,0.4217,0.5783,RH,LH
+2018-08-09,Anastasija Sevastova,Julia Goerges,0.3558,0.6442,LH,LH
+2018-08-09,Elina Svitolina,Johanna Konta,0.4639,0.536,LH,RH
+2018-08-10,Elise Mertens,Aryna Sabalenka,0.4749,0.5251,RH,RH
+2018-08-10,Simona Halep,Venus Williams,0.4685,0.5315,RH,LH
+2018-08-10,Ashleigh Barty,Kiki Bertens,0.4775,0.5225,LH,LH
+2018-08-10,Sloane Stephens,Anastasija Sevastova,0.5005,0.4995,LH,RH
+2018-08-10,Simona Halep,Caroline Garcia,0.5845,0.4155,RH,RH
+2018-08-11,Elina Svitolina,Elise Mertens,0.4924,0.5076,RH,LH
+2018-08-11,Simona Halep,Ashleigh Barty,0.4328,0.5672,LH,LH
+2018-08-11,Sloane Stephens,Elina Svitolina,0.5473,0.4527,LH,RH
+2018-08-13,Aryna Sabalenka,Johanna Konta,0.6064,0.3936,RH,RH
+2018-08-14,Alize Cornet,Jelena Ostapenko,0.2971,0.7029,RH,LH
+2018-08-14,Elise Mertens,Magdalena Rybarikova,0.517,0.4829,LH,LH
+2018-08-14,Karolina Pliskova,Agnieszka Radwanska,0.5539,0.4461,LH,RH
+2018-08-14,Kiki Bertens,Coco Vandeweghe,0.3747,0.6254,RH,RH
+2018-08-14,Petra Martic,Daria Kasatkina,0.6001,0.3999,RH,LH
+2018-08-15,Elina Svitolina,Svetlana Kuznetsova,0.4658,0.5342,LH,LH
+2018-08-15,Aryna Sabalenka,Karolina Pliskova,0.5156,0.4843,LH,RH
+2018-08-15,Sloane Stephens,Tatjana Maria,0.3296,0.6704,RH,RH
+2018-08-15,Lesia Tsurenko,Garbine Muguruza,0.5652,0.4348,RH,LH
+2018-08-16,Kiki Bertens,Caroline Wozniacki,0.5563,0.4437,LH,LH
+2018-08-16,Aryna Sabalenka,Caroline Garcia,0.596,0.4039,LH,RH
+2018-08-16,Elise Mertens,Sloane Stephens,0.5391,0.4609,RH,RH
+2018-08-17,Simona Halep,Ashleigh Barty,0.4328,0.5672,RH,LH
+2018-08-17,Kiki Bertens,Anett Kontaveit,0.4884,0.5116,LH,LH
+2018-08-17,Simona Halep,Lesia Tsurenko,0.5283,0.4717,LH,RH
+2018-08-17,Kiki Bertens,Elina Svitolina,0.5921,0.4078,RH,RH
+2018-08-18,Aryna Sabalenka,Madison Keys,0.6043,0.3957,RH,LH
+2018-08-19,Magdalena Rybarikova,Coco Vandeweghe,0.5112,0.4888,LH,LH
+2018-08-19,Julia Goerges,Dominika Cibulkova,0.7224,0.2776,LH,RH
+2018-08-20,Aliaksandra Sasnovich,Kristina Mladenovic,0.4158,0.5841,RH,RH
+2018-08-24,Aryna Sabalenka,Julia Goerges,0.4618,0.5382,RH,LH
+2018-08-27,Kaia Kanepi,Simona Halep,0.4597,0.5403,LH,LH
+2018-08-27,Garbine Muguruza,Shuai Zhang,0.4632,0.5368,LH,RH
+2018-08-27,Venus Williams,Svetlana Kuznetsova,0.4659,0.5341,RH,RH
+2018-08-27,Anastasija Sevastova,Donna Vekic,0.5363,0.4637,RH,LH
+2018-08-28,Caroline Wozniacki,Samantha Stosur,0.5272,0.4728,LH,LH
+2018-08-28,Kirsten Flipkens,Coco Vandeweghe,0.5391,0.4609,LH,RH
+2018-08-28,Kiki Bertens,Karolina Pliskova,0.4808,0.5192,RH,RH
+2018-08-28,Aliaksandra Sasnovich,Belinda Bencic,0.5228,0.4772,RH,LH
+2018-08-28,Caroline Garcia,Johanna Konta,0.5115,0.4885,LH,LH
+2018-08-29,Kristina Mladenovic,Tamara Zidansek,0.6387,0.3613,LH,RH
+2018-08-29,Elina Svitolina,Tatjana Maria,0.4632,0.5368,RH,RH
+2018-08-29,Qiang Wang,Irina Camelia Begu,0.5518,0.4481,RH,LH
+2018-08-30,Sofia Kenin,Maria Sakkari,0.4353,0.5648,LH,LH
+2018-08-30,Aliaksandra Sasnovich,Daria Kasatkina,0.4857,0.5143,LH,RH
+2018-08-30,Dominika Cibulkova,Su Wei Hsieh,0.5901,0.4099,RH,RH
+2018-08-31,Lesia Tsurenko,Caroline Wozniacki,0.3916,0.6083,RH,LH
+2018-09-01,Carla Suarez Navarro,Caroline Garcia,0.5116,0.4884,LH,LH
+2018-09-02,Karolina Pliskova,Ashleigh Barty,0.6098,0.3902,LH,RH
+2018-09-02,Anastasija Sevastova,Elina Svitolina,0.4693,0.5307,RH,RH
+2018-09-03,Sloane Stephens,Elise Mertens,0.4375,0.5625,RH,LH
+2018-09-03,Naomi Osaka,Aryna Sabalenka,0.3101,0.6899,LH,LH
+2018-09-04,Carla Suarez Navarro,Maria Sharapova,0.4526,0.5474,LH,RH
+2018-09-04,Anastasija Sevastova,Sloane Stephens,0.5732,0.4268,RH,RH
+2018-09-05,Naomi Osaka,Lesia Tsurenko,0.4941,0.5059,RH,LH
+2018-09-06,Madison Keys,Carla Suarez Navarro,0.5305,0.4695,LH,LH
+2018-09-07,Serena Williams,Anastasija Sevastova,0.5764,0.4236,LH,RH
+2018-09-07,Naomi Osaka,Madison Keys,0.496,0.504,RH,RH
+2018-09-15,Su Wei Hsieh,Qiang Wang,0.5608,0.4392,RH,LH
+2018-09-10,Christina Mchale,Dayana Yastremska,0.3455,0.6545,LH,LH
+2018-09-19,Ajla Tomljanovic,Tamara Zidansek,0.4104,0.5896,LH,RH
+2018-09-21,Maria Sakkari,Irina Camelia Begu,0.5459,0.4541,RH,RH
+2018-09-22,Kiki Bertens,Maria Sakkari,0.5495,0.4505,RH,LH
+2018-09-18,Ashleigh Barty,Coco Vandeweghe,0.4528,0.5472,LH,LH
+2018-09-19,Naomi Osaka,Dominika Cibulkova,0.6033,0.3968,LH,RH
+2018-09-20,Donna Vekic,Johanna Konta,0.5112,0.4888,RH,RH
+2018-09-22,Karolina Pliskova,Donna Vekic,0.6511,0.3489,RH,LH
+2018-09-23,Karolina Pliskova,Naomi Osaka,0.6077,0.3923,LH,LH
+2018-09-23,Katerina Siniakova,Kristina Mladenovic,0.3648,0.6352,LH,RH
+2018-09-23,Anastasia Pavlyuchenkova,Anastasija Sevastova,0.5696,0.4304,RH,RH
+2018-09-23,Daria Kasatkina,Lesia Tsurenko,0.4032,0.5968,RH,LH
+2018-09-23,Aliaksandra Sasnovich,Elise Mertens,0.4365,0.5635,LH,LH
+2018-09-24,Aryna Sabalenka,Carla Suarez Navarro,0.6381,0.3619,LH,RH
+2018-09-24,Ashleigh Barty,Johanna Konta,0.4846,0.5154,RH,RH
+2018-09-25,Aryna Sabalenka,Elina Svitolina,0.5774,0.4226,RH,LH
+2018-09-25,Anastasia Pavlyuchenkova,Kiki Bertens,0.5892,0.4108,LH,LH
+2018-09-26,Dominika Cibulkova,Daria Kasatkina,0.5966,0.4034,LH,RH
+2018-09-26,Katerina Siniakova,Garbine Muguruza,0.3679,0.6321,RH,RH
+2018-09-27,Ashleigh Barty,Anastasia Pavlyuchenkova,0.5126,0.4874,RH,LH
+2018-09-28,Anett Kontaveit,Qiang Wang,0.494,0.506,LH,LH
+2018-09-28,Aryna Sabalenka,Ashleigh Barty,0.5899,0.4101,LH,RH
+2018-09-29,Aryna Sabalenka,Anett Kontaveit,0.6741,0.3259,RH,RH
+2018-09-29,Jelena Ostapenko,Magdalena Rybarikova,0.553,0.447,RH,LH
+2018-09-29,Julia Goerges,Johanna Konta,0.6371,0.3629,LH,LH
+2018-09-30,Ons Jabeur,Simona Halep,0.423,0.577,LH,RH
+2018-09-30,Sloane Stephens,Anastasia Pavlyuchenkova,0.3415,0.6585,RH,RH
+2018-09-30,Kiki Bertens,Sorana Cirstea,0.6623,0.3377,RH,LH
+2018-10-01,Karolina Pliskova,Samantha Stosur,0.5942,0.4058,LH,LH
+2018-10-01,Carla Suarez Navarro,Yulia Putintseva,0.5669,0.4331,LH,RH
+2018-10-01,Shuai Zhang,Elise Mertens,0.5253,0.4747,RH,RH
+2018-10-01,Julia Goerges,Lesia Tsurenko,0.6619,0.3381,RH,LH
+2018-10-01,Anastasija Sevastova,Madison Keys,0.5509,0.4491,LH,LH
+2018-10-02,Aryna Sabalenka,Garbine Muguruza,0.6661,0.3339,LH,RH
+2018-10-03,Caroline Wozniacki,Petra Martic,0.5486,0.4514,RH,RH
+2018-10-03,Anastasija Sevastova,Donna Vekic,0.5406,0.4594,RH,LH
+2018-10-03,Dominika Cibulkova,Sloane Stephens,0.4901,0.5099,LH,LH
+2018-10-04,Naomi Osaka,Julia Goerges,0.3868,0.6133,LH,RH
+2018-10-04,Caroline Wozniacki,Anett Kontaveit,0.6325,0.3674,RH,RH
+2018-10-04,Aryna Sabalenka,Caroline Garcia,0.6316,0.3684,RH,LH
+2018-10-05,Anastasija Sevastova,Dominika Cibulkova,0.6643,0.3357,LH,LH
+2018-10-05,Caroline Wozniacki,Katerina Siniakova,0.5947,0.4053,LH,RH
+2018-10-06,Anastasija Sevastova,Naomi Osaka,0.4646,0.5354,RH,RH
+2018-10-06,Caroline Wozniacki,Qiang Wang,0.6564,0.3436,RH,LH
+2018-10-07,Caroline Wozniacki,Anastasija Sevastova,0.5349,0.4651,LH,LH
+2018-10-13,Qiang Wang,Elina Svitolina,0.3908,0.6092,LH,RH
+2018-10-13,Qiang Wang,Garbine Muguruza,0.5131,0.4869,RH,RH
+2018-10-12,Su Wei Hsieh,Elise Mertens,0.4229,0.5771,RH,LH
+2018-10-13,Caroline Garcia,Su Wei Hsieh,0.5196,0.4803,LH,LH
+2018-10-14,Caroline Garcia,Karolina Pliskova,0.4154,0.5846,LH,RH
+2018-10-16,Carla Suarez Navarro,Karolina Pliskova,0.4985,0.5015,RH,RH
+2018-10-18,Julia Goerges,Donna Vekic,0.6541,0.3459,RH,LH
+2018-10-15,Daria Kasatkina,Lesia Tsurenko,0.4139,0.5861,LH,LH
+2018-10-16,Johanna Konta,Elise Mertens,0.5432,0.4568,LH,RH
+2018-10-17,Anastasija Sevastova,Yulia Putintseva,0.6666,0.3334,RH,RH
+2018-10-18,Daria Kasatkina,Anastasia Pavlyuchenkova,0.3217,0.6783,RH,LH
+2018-10-19,Daria Kasatkina,Johanna Konta,0.4013,0.5987,LH,LH
+2018-10-21,Karolina Pliskova,Caroline Wozniacki,0.5133,0.4867,LH,RH
+2018-10-22,Sloane Stephens,Naomi Osaka,0.4334,0.5666,RH,RH
+2018-10-23,Elina Svitolina,Karolina Pliskova,0.4608,0.5392,RH,LH
+2018-10-24,Sloane Stephens,Kiki Bertens,0.4502,0.5498,LH,LH
+2018-10-25,Elina Svitolina,Caroline Wozniacki,0.4821,0.5179,LH,RH
+2018-10-26,Kiki Bertens,Naomi Osaka,0.5333,0.4667,RH,RH
+2018-10-27,Elina Svitolina,Kiki Bertens,0.5063,0.4937,RH,LH
+2018-10-27,Sloane Stephens,Karolina Pliskova,0.4289,0.5711,LH,LH
+2018-10-28,Elina Svitolina,Sloane Stephens,0.6012,0.3988,LH,RH
+2018-10-30,Aryna Sabalenka,Ashleigh Barty,0.58,0.42,RH,RH
+2018-10-30,Elise Mertens,Anett Kontaveit,0.4991,0.5009,RH,LH
+2018-10-30,Daria Kasatkina,Qiang Wang,0.3536,0.6464,LH,LH
+2018-10-31,Anett Kontaveit,Julia Goerges,0.3572,0.6428,LH,RH
+2018-10-31,Madison Keys,Daria Kasatkina,0.628,0.372,RH,RH
+2018-10-31,Garbine Muguruza,Shuai Zhang,0.5088,0.4911,RH,LH
+2018-11-01,Ashleigh Barty,Caroline Garcia,0.5215,0.4785,LH,LH
+2018-11-01,Julia Goerges,Elise Mertens,0.6651,0.335,LH,RH
+2018-11-02,Caroline Garcia,Aryna Sabalenka,0.3775,0.6225,RH,RH
+2018-11-02,Garbine Muguruza,Anastasija Sevastova,0.3877,0.6123,RH,LH
+2018-11-02,Qiang Wang,Madison Keys,0.4656,0.5344,LH,LH
+2018-11-03,Ashleigh Barty,Julia Goerges,0.3439,0.6561,LH,RH
+2018-11-03,Qiang Wang,Garbine Muguruza,0.5103,0.4897,RH,RH
+2018-11-04,Ashleigh Barty,Qiang Wang,0.5705,0.4295,RH,LH

--- a/Multi_PCSP_Generator.py
+++ b/Multi_PCSP_Generator.py
@@ -1,0 +1,16 @@
+from csv import DictReader
+from datetime import date, timedelta
+
+from Generate_PCSP import generate_pcsp
+
+with open('MDP_pred.csv', newline='') as pred_file:
+    pred_reader = DictReader(pred_file)
+    row_num = 1
+    for row in pred_reader:
+        end_date = date.fromisoformat(row['date']) - timedelta(days=1)
+        pcsp_filename = f"{row_num}.pcsp"
+        generate_pcsp(
+            end_date.isoformat(), row['P1Name'], row['P2Name'], row['P1Hand'], row['P2Hand'], pcsp_filename
+        )
+        print(f"Generated {pcsp_filename}")
+        row_num += 1

--- a/generate_pcsp_helpers/setup.py
+++ b/generate_pcsp_helpers/setup.py
@@ -2,25 +2,25 @@ import sys
 
 
 def get_args():
-    date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender = '2021-02-21', 'Novak Djokovic', 'Daniil Medvedev', 'RH', 'RH', 'M'
+    date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender, pcsp_filename = '2021-02-21', 'Novak Djokovic', 'Daniil Medvedev', 'RH', 'RH', 'M', '1.pcsp'
     program_name = sys.argv[0]
 
     # Read arguments date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender from CLI
-    if len(sys.argv) != 7:
+    if len(sys.argv) != 8:
         print("------------------------------------------------------------------------------------------------------------------------")
         print(
-            f"Usage: python3 {program_name} <date> <ply1_name> <ply2_name> <ply1_hand> ply2_hand> <gender>")
+            f"Usage: python3 {program_name} <date> <ply1_name> <ply2_name> <ply1_hand> ply2_hand> <gender> <pcsp_filename>")
         print("------------------------------------------------------------------------------------------------------------------------")
         print(
-            f"Falling back to default values:\n  date: {date}\n  ply1_name: {ply1_name}\n  ply2_name: {ply2_name}\n  ply1_hand: {ply1_hand}\n  ply2_hand: {ply2_hand}\n  gender: {gender}"
+            f"Falling back to default values:\n  date: {date}\n  ply1_name: {ply1_name}\n  ply2_name: {ply2_name}\n  ply1_hand: {ply1_hand}\n  ply2_hand: {ply2_hand}\n  gender: {gender}\n pcsp_filename: {pcsp_filename}"
         )
         print("------------------------------------------------------------------------------------------------------------------------")
     else:
-        date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender = sys.argv[1:]
+        date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender, pcsp_filename = sys.argv[1:]
         print("------------------------------------------------------------------------------------------------------------------------")
         print(
-            f"Using values:\n  date: {date}\n  ply1_name: {ply1_name}\n  ply2_name: {ply2_name}\n  ply1_hand: {ply1_hand}\n  ply2_hand: {ply2_hand}\n  gender: {gender}"
+            f"Using values:\n  date: {date}\n  ply1_name: {ply1_name}\n  ply2_name: {ply2_name}\n  ply1_hand: {ply1_hand}\n  ply2_hand: {ply2_hand}\n  gender: {gender}\n pcsp_filename: {pcsp_filename}"
         )
         print("------------------------------------------------------------------------------------------------------------------------")
 
-    return date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender
+    return date, ply1_name, ply2_name, ply1_hand, ply2_hand, gender, pcsp_filename


### PR DESCRIPTION
Closes #3 

Use function call instead of executing the script multiple times. Makes it faster as it only has to load the tennisabstract csv once. Did not use the "Gender" header as it does not seem to be used. Run script as
```
python3 Multi_PCSP_Generator.py
```

Files will be output as 1.pcsp, 2.pcsp, ...